### PR TITLE
Fix error when visiting /help

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,7 @@ Rails.application.routes.draw do
   resources :follows, only: [:create, :destroy]
 
   # More info pages
-  get "help",             to: "pages#show", id: "help/index",             as: "help"
+  get "help",             to: "pages#show", id: "vragen",                 as: "help"
   get "help/how-to-use",  to: "pages#show", id: "help/how_to_use/index",  as: "how_to_use"
   get "help/faq",         to: "pages#show", id: "faq",                    as: "faq"
 

--- a/spec/features/help_page_spec.rb
+++ b/spec/features/help_page_spec.rb
@@ -6,6 +6,7 @@ describe "Help page" do
 
     scenario "Help menu and page is visible if feature is enabled" do
       Setting["feature.help_page"] = true
+      customize_help_page
 
       visit root_path
 

--- a/spec/features/site_customization/custom_pages_spec.rb
+++ b/spec/features/site_customization/custom_pages_spec.rb
@@ -79,6 +79,7 @@ describe "Custom Pages" do
           subtitle_en: "Subtitle for custom page",
           more_info_flag: true
         )
+        customize_help_page
 
         visit help_path
 
@@ -87,19 +88,20 @@ describe "Custom Pages" do
 
       scenario "Not listed in more information page" do
         custom_page = create(:site_customization_page, :published,
-          slug: "another-slug", title_en: "Another custom page",
+          slug: "another-slug", title_en: "Unpublished custom page",
           subtitle_en: "Subtitle for custom page",
           more_info_flag: false
         )
+        customize_help_page
 
         visit help_path
 
-        expect(page).not_to have_content("Another custom page")
+        expect(page).not_to have_content("Unpublished custom page")
 
         visit custom_page.url
 
-        expect(page).to have_title("Another custom page")
-        expect(page).to have_selector("h1", text: "Another custom page")
+        expect(page).to have_title("Unpublished custom page")
+        expect(page).to have_selector("h1", text: "Unpublished custom page")
         expect(page).to have_content("Subtitle for custom page")
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ RSpec.configure do |config|
   config.include(EmailSpec::Helpers)
   config.include(EmailSpec::Matchers)
   config.include(CommonActions)
+  config.include(CustomCommonActions)
   config.include(ActiveSupport::Testing::TimeHelpers)
 
   config.before(:suite) do

--- a/spec/support/custom_common_actions.rb
+++ b/spec/support/custom_common_actions.rb
@@ -1,0 +1,11 @@
+module CustomCommonActions
+
+  def customize_help_page
+    SiteCustomization::Page.create!(
+      slug: "vragen",
+      status: "published",
+      title: "CONSUL is a platform for citizen participation",
+      content: "Another custom page")
+  end
+
+end


### PR DESCRIPTION
## Objectives

Since Groningen has a custom help page with a different slug we need to route the help page to that custom slug

