### PR TITLE
Custom texts

### DIFF
--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -175,7 +175,7 @@ class Budget < ApplicationRecord
     when "finished"
       %w{random}
     else
-      %w{random confidence_score}
+      %w{confidence_score random}
     end
   end
 

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -76,7 +76,7 @@
                   <% unless current_budget.informing? || current_budget.finished? %>
                     <%= link_to budget_investments_path(current_budget.id,
                                                         heading_id: heading.id) do %>
-                      <%= heading_name_and_price_html(heading, current_budget) %>
+                      <%= t("budgets.index.go_to_ideas") %>
                     <% end %>
                   <% else %>
                     <div class="heading-name">

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -104,11 +104,13 @@
                 <% end %>
               </li>
             <% end %>
+            <% if false %>
             <li>
               <%= link_to budget_path(current_budget, filter: "unfeasible") do %>
                 <small><%= t("budgets.index.unfeasible_investment_proyects") %></small>
               <% end %>
             </li>
+            <% end %>
             <% if show_unselected_link_to_budget_investments(current_budget) %>
               <li>
                 <%= link_to budget_path(current_budget, filter: "unselected") do %>

--- a/app/views/budgets/investments/_header.html.erb
+++ b/app/views/budgets/investments/_header.html.erb
@@ -51,10 +51,6 @@
             <h2 class="margin-top">
               <%= t("budgets.investments.index.by_heading", heading: @heading.name) %>
             </h2>
-            <h3>
-              <span class="tagline"><%= t("budgets.investments.header.price") %></span>
-              <%= @budget.formatted_heading_price(@heading) %>
-            </h3>
           <% end %>
         </div>
       </div>

--- a/app/views/budgets/investments/_header.html.erb
+++ b/app/views/budgets/investments/_header.html.erb
@@ -51,6 +51,7 @@
             <h2 class="margin-top">
               <%= t("budgets.investments.index.by_heading", heading: @heading.name) %>
             </h2>
+            <p><%= t("budgets.investments.index.by_heading_description") %></p>
           <% end %>
         </div>
       </div>

--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -92,7 +92,7 @@
         </div>
       </div>
 
-      <div id="sidebar" class="small-12 medium-3 column">
+      <aside id="sidebar" class="small-12 medium-3 column">
         <% if can_destroy_image?(investment) || can?(:edit, investment) %>
           <div class="sidebar-divider"></div>
           <p class="sidebar-title"><%= t("budgets.investments.show.author") %></p>
@@ -216,7 +216,7 @@
 
         <%= render "communities/access_button", community: investment.community %>
 
-       </div>
+      </aside>
     </div>
   </section>
 <% end %>

--- a/app/views/budgets/investments/_sidebar.html.erb
+++ b/app/views/budgets/investments/_sidebar.html.erb
@@ -27,8 +27,6 @@
 <% if @map_location&.available? %>
   <%= render "budgets/investments/map" %>
 <% end %>
-<%= render "shared/tag_cloud", taggable: "budget/investment" %>
-<%= render "budgets/investments/categories" %>
 
 <% if @heading && can?(:show, @ballot) %>
 

--- a/app/views/custom/layouts/_footer.html.erb
+++ b/app/views/custom/layouts/_footer.html.erb
@@ -57,7 +57,7 @@
       <p class="info">
         <%= t("layouts.footer.contact",
                email: link_to(t("layouts.footer.email"),
-                      "mailto:cooperatieve.wijkraad@groningen.nl")).html_safe %>
+                      "mailto:destemvan@groningen.nl")).html_safe %>
       </p>
     </div>
 

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -218,6 +218,7 @@ ignore_unused:
   - "budgets.investments.show.code_html"
   - "mailers.budget_investment_unfeasible.sorry"
   - "stats.budgets.link"
+  - "budgets.investments.header.price"
 ####
 ## Exclude these keys from the `i18n-tasks eq-base" report:
 # ignore_eq_base:

--- a/config/initializers/social_share_button.rb
+++ b/config/initializers/social_share_button.rb
@@ -1,3 +1,3 @@
 SocialShareButton.configure do |config|
-  config.allow_sites = %w(twitter facebook google_plus telegram)
+  config.allow_sites = %w(twitter facebook telegram)
 end

--- a/config/locales/custom/en/budgets.yml
+++ b/config/locales/custom/en/budgets.yml
@@ -1,5 +1,7 @@
 en:
   budgets:
+    index:
+      go_to_ideas: "Go to ideas"
     investments:
       form:
         updated_notice: Investment project updated successfully.

--- a/config/locales/custom/en/budgets.yml
+++ b/config/locales/custom/en/budgets.yml
@@ -5,3 +5,5 @@ en:
     investments:
       form:
         updated_notice: Investment project updated successfully.
+      index:
+        by_heading_description: "Between l'Alsace Avenue and Maple Avenue"

--- a/config/locales/custom/nl/admin.yml
+++ b/config/locales/custom/nl/admin.yml
@@ -1,5 +1,7 @@
 nl:
   admin:
+    actions:
+      hide: "verbergen"
     tags:
       create: "Creëer onderwerp"
     spending_proposals:

--- a/config/locales/custom/nl/budgets.yml
+++ b/config/locales/custom/nl/budgets.yml
@@ -22,13 +22,17 @@ nl:
       investment_proyects: Lijst van alle gekozen ideeën
       not_selected_investment_proyects: Niet voor stemmen geselecteerde ideeën bekijken
       see_results: Bekijk de uitslag
+      finished_budgets: "Afgeronde processen"
     investments:
       index:
+        by_heading: "Ideeën voor %{heading}"
+        orders:
+          confidence_score: "meest populair"
         sidebar:
           by_feasibility: Op haalbaarheid
           change_ballot: Als u zich bedenkt kunt uw uw stemmen in %{check_ballot} verwijderen opnieuw beginnen.
           check_ballot_link: check mijn stemming
-          create: Nieuw idee maken
+          create: "Idee toevoegen"
           different_heading_assigned_html: 'Je hebt al gestemd al op een ander deel van het budget: %{heading_link}'
           feasible: Haalbare budgetten ideeën
           my_ballot: Mijn stemmen
@@ -45,9 +49,19 @@ nl:
         edit_permission: "Je moet zelf het idee hebben ingediend om het te kunnen bewerken."
         updated_notice: "Je idee is aangepast."
       show:
+        author: "auteur"
         comments_tab: Reacties
+        supports: "Steun"
+      investment:
+        give_support: "Like"
+        supports:
+          zero: "nog geen likes"
+          one: "1 like"
+          other: "%{count} likes"
     phase:
       finished: De uitslag
+      selecting: "Stemmen op ideeën"
+      balloting: "Stemmen tellen"
     results:
       link: De uitslag
       investment_title: Idee

--- a/config/locales/custom/nl/budgets.yml
+++ b/config/locales/custom/nl/budgets.yml
@@ -26,7 +26,8 @@ nl:
       go_to_ideas: "Ga naar ideeën"
     investments:
       index:
-        by_heading: "Ideeën voor %{heading}"
+        by_heading: "Wat wilt ú bij de vijver aan de Mispellaan?"
+        by_heading_description: "Tussen de Elzenlaan en de Esdoornlaan"
         orders:
           confidence_score: "meest populair"
         sidebar:

--- a/config/locales/custom/nl/budgets.yml
+++ b/config/locales/custom/nl/budgets.yml
@@ -23,6 +23,7 @@ nl:
       not_selected_investment_proyects: Niet voor stemmen geselecteerde ideeën bekijken
       see_results: Bekijk de uitslag
       finished_budgets: "Afgeronde processen"
+      go_to_ideas: "Ga naar ideeën"
     investments:
       index:
         by_heading: "Ideeën voor %{heading}"

--- a/config/locales/custom/nl/devise_views.yml
+++ b/config/locales/custom/nl/devise_views.yml
@@ -25,6 +25,11 @@ nl:
           organization_signup: Lees hier de %{signup_link}.
           organization_signup_link: gebruiksvoorwaarden
           submit: Registreren
-          terms: Ik ben een Oosterparker en ik accepteer de gebruiksvoorwaarden.
+          terms: "Ik ben een inwoner van Groningen en ik accepteer de gebruiksvoorwaarden."
           username_label: Gebruikersnaam
           username_note: De opgegeven naam zal zichtbaar zijn voor andere gebruikers
+        success:
+          title: "Bevestig uw mailadres"
+          thank_you_html: "Bedankt voor uw aanmelding."
+          instructions_1_html: "Bevestig uw mailadres via de link die wij u hebben toegestuurd."
+          instructions_2_html: "<strong>Let op</strong>: controleer ook uw spam inbox."

--- a/config/locales/custom/nl/general.yml
+++ b/config/locales/custom/nl/general.yml
@@ -18,6 +18,7 @@ nl:
       save_changes_submit: Wijzigingen opslaan
   shared:
     back: Ga terug
+    edit: "Aanpassen"
     view_mode:
       cards: Overzicht
       title: Weergave
@@ -33,7 +34,7 @@ nl:
       my_activity_link: Mijn bijdragen
     footer:
       contact: Neem contact op met %{email}
-      email: cooperatieve.wijkraad@groningen.nl
+      email: "destemvan@groningen.nl"
       groningen: Stem van Groningen
       groningen_description: Dit is het online participatieplatform van Groningen. De Coöperatieve Wijkraad gebruikt dit platform voor 'Altijd een goed idee'
       questions: Vragen?
@@ -85,3 +86,16 @@ nl:
         retired: Voorstel ingetrokken
         retired_warning: Dit voorstel is ingetrokken.
         retired_warning_link_to_explanation: Lees waarom.
+  comments:
+    comment:
+      responses_show:
+        one: "1 reactie (tonen)"
+        other: "%{count} reacties (tonen)"
+        zero: "Geen reacties"
+      responses_collapse:
+        one: "1 reactie (verbergen)"
+        other: "%{count} reacties (verbergen)"
+        zero: "Geen reacties"
+  users:
+    show:
+      comments: "Reacties"

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -61,10 +61,11 @@ describe "Budgets" do
       within("#budget_info") do
         expect(page).to have_content(group1.name)
         expect(page).to have_content(group2.name)
-        expect(page).to have_content(heading1.name)
-        expect(page).to have_content(budget.formatted_heading_price(heading1))
-        expect(page).to have_content(heading2.name)
-        expect(page).to have_content(budget.formatted_heading_price(heading2))
+        # expect(page).to have_content(heading1.name)
+        # expect(page).to have_content(budget.formatted_heading_price(heading1))
+        # expect(page).to have_content(heading2.name)
+        # expect(page).to have_content(budget.formatted_heading_price(heading2))
+        expect(page).to have_link("Go to ideas", count: 2)
       end
 
       expect(page).not_to have_content("#finished_budgets")
@@ -84,7 +85,7 @@ describe "Budgets" do
       end
     end
 
-    scenario "Show headings ordered by name" do
+    xscenario "Show headings ordered by name" do
       group = create(:budget_group, budget: budget)
       last_heading = create(:budget_heading, group: group, name: "BBB")
       first_heading = create(:budget_heading, group: group, name: "AAA")
@@ -94,7 +95,7 @@ describe "Budgets" do
       expect(first_heading.name).to appear_before(last_heading.name)
     end
 
-    scenario "Show groups and headings for missing translations" do
+    xscenario "Show groups and headings for missing translations" do
       group1 = create(:budget_group, budget: budget)
       group2 = create(:budget_group, budget: budget)
 

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -146,8 +146,8 @@ describe "Budgets" do
         expect(page).to have_link "List of all investment projects",
                                    href: budget_path(budget)
 
-        expect(page).to have_link "List of all unfeasible investment projects",
-                                   href: budget_path(budget, filter: "unfeasible")
+        # expect(page).to have_link "List of all unfeasible investment projects",
+        #                            href: budget_path(budget, filter: "unfeasible")
 
         expect(page).not_to have_link "List of all investment projects not selected for balloting",
                                       href: budget_path(budget, filter: "unselected")
@@ -168,7 +168,7 @@ describe "Budgets" do
         visit budgets_path
 
         expect(page).to have_content(I18n.t("budgets.index.investment_proyects"))
-        expect(page).to have_content(I18n.t("budgets.index.unfeasible_investment_proyects"))
+        #expect(page).to have_content(I18n.t("budgets.index.unfeasible_investment_proyects"))
         unless budget.phase == "finished"
           expect(page).to have_content(I18n.t("budgets.index.not_selected_investment_proyects"))
         end
@@ -191,7 +191,7 @@ describe "Budgets" do
         visit budgets_path
 
         expect(page).not_to have_content(I18n.t("budgets.index.investment_proyects"))
-        expect(page).to have_content(I18n.t("budgets.index.unfeasible_investment_proyects"))
+        #expect(page).to have_content(I18n.t("budgets.index.unfeasible_investment_proyects"))
         unless budget.phase == "finished"
           expect(page).not_to have_content(I18n.t("budgets.index.not_selected_investment_proyects"))
         end

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -1522,7 +1522,8 @@ describe "Budget Investments" do
 
       first(:link, "Participatory budgeting").click
 
-      click_link "More hospitals €666,666"
+      #click_link "More hospitals €666,666"
+      click_link "Go to ideas"
 
       within("#budget_investment_#{investment1.id}") do
         expect(page).to have_content investment1.title

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -632,14 +632,20 @@ describe "Budget Investments" do
     before { budget.update(phase: "selecting") }
     let(:per_page) { Budgets::InvestmentsController::PER_PAGE }
 
-    scenario "Default order is random" do
+    scenario "Default order is confident score" do
       (per_page + 2).times { create(:budget_investment, heading: heading) }
+
+      budget.investments.order(:id).find_each do |investment|
+        investment.update_columns(confidence_score: investment.id)
+      end
+      expected_order = budget.investments.order(:id).map(&:title).reverse.first(per_page)
 
       visit budget_investments_path(budget, heading_id: heading.id)
 
-      within(".submenu .is-active") { expect(page).to have_content "random" }
+      within(".submenu .is-active") { expect(page).to have_content "highest rated" }
       order = all(".budget-investment h3").collect { |i| i.text }
       expect(order).not_to be_empty
+      expect(order).to eq expected_order
 
       visit budget_investments_path(budget, heading_id: heading.id)
       new_order = all(".budget-investment h3").collect { |i| i.text }
@@ -739,11 +745,13 @@ describe "Budget Investments" do
 
       in_browser(:one) do
         visit budget_investments_path(budget, heading: heading)
+        click_link "random"
         @first_user_investments_order = investments_order
       end
 
       in_browser(:two) do
         visit budget_investments_path(budget, heading: heading)
+        click_link "random"
         @second_user_investments_order = investments_order
       end
 

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -87,7 +87,7 @@ describe "Debates" do
     expect(page.html).to include "<title>#{debate.title}</title>"
 
     within(".social-share-button") do
-      expect(page.all("a").count).to be(4) # Twitter, Facebook, Google+, Telegram
+      expect(page.all("a").count).to be(3) # Twitter, Facebook, Telegram
     end
   end
 

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -134,7 +134,7 @@ describe "Proposals" do
     expect(page).not_to have_selector ".js-follow"
 
     within(".social-share-button") do
-      expect(page.all("a").count).to be(4) # Twitter, Facebook, Google+, Telegram
+      expect(page.all("a").count).to be(3) # Twitter, Facebook, Telegram
     end
   end
 

--- a/spec/features/tags/budget_investments_spec.rb
+++ b/spec/features/tags/budget_investments_spec.rb
@@ -233,7 +233,7 @@ describe "Tags" do
     let!(:investment2) { create(:budget_investment, heading: heading, tag_list: new_tag) }
     let!(:investment3) { create(:budget_investment, heading: heading, tag_list: newer_tag) }
 
-    scenario "Display user tags" do
+    xscenario "Display user tags" do
       Budget::Phase::PHASE_KINDS.each do |phase|
         budget.update(phase: phase)
 
@@ -247,7 +247,7 @@ describe "Tags" do
       end
     end
 
-    scenario "Filter by user tags" do
+    xscenario "Filter by user tags" do
       Budget::Phase::PHASE_KINDS.each do |phase|
         budget.update(phase: phase)
 
@@ -278,7 +278,7 @@ describe "Tags" do
 
   end
 
-  context "Categories" do
+  xcontext "Categories" do
 
     let!(:investment1) { create(:budget_investment, heading: heading, tag_list: tag_medio_ambiente.name) }
     let!(:investment2) { create(:budget_investment, heading: heading, tag_list: tag_medio_ambiente.name) }

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -214,11 +214,11 @@ describe Budget do
       budget.phase = "reviewing_ballots"
       expect(budget.investments_orders).to eq(["random", "price"])
     end
-    it "is random and confidence_score in all other cases" do
+    it "is confidence_score and random in all other cases" do
       budget.phase = "selecting"
-      expect(budget.investments_orders).to eq(["random", "confidence_score"])
+      expect(budget.investments_orders).to eq(["confidence_score", "random"])
       budget.phase = "valuating"
-      expect(budget.investments_orders).to eq(["random", "confidence_score"])
+      expect(budget.investments_orders).to eq(["confidence_score", "random"])
     end
   end
 


### PR DESCRIPTION
## Objectives

- Update custom texts.
- Fix aside HTML tag on the sidebar.
- Hide unused content:
    - Hide unfeasible investment projects link.
    - Heading price.
    - Tag cloud and categories.
- Change link to heading text on budgets index.
- Disable Google+ share button.
- Add custom text on budget investments header.
- Change the order of budget investments filters menu.