### PR TITLE
Precompile CKEditor dialog plugins

### DIFF
--- a/config/initializers/ckeditor.rb
+++ b/config/initializers/ckeditor.rb
@@ -8,5 +8,5 @@ Ckeditor.setup do |config|
   config.authorize_with :cancan
 
   config.assets_languages = Rails.application.config.i18n.available_locales.map{|l| l.to_s.downcase}
-  config.assets_plugins = %w[copyformatting tableselection scayt wsc]
+  config.assets_plugins = %w[copyformatting image link magicline scayt table tableselection wsc]
 end


### PR DESCRIPTION
## Objectives
Fix an issue with CKEditor in CONSUL version 1.0

In some cases, in the production environment the dialogs for links, images and tables didn't work, because these plugins were not precompiled.
