### PR TITLE
Groningen Adjustments

### DIFF
--- a/app/assets/javascripts/map.js
+++ b/app/assets/javascripts/map.js
@@ -83,6 +83,7 @@
       };
       mapCenterLatLng = new L.LatLng(mapCenterLatitude, mapCenterLongitude);
       map = L.map(element.id).setView(mapCenterLatLng, zoom);
+      map.scrollWheelZoom.disable();
       L.tileLayer(mapTilesProvider, {
         attribution: mapAttribution
       }).addTo(map);

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -708,6 +708,13 @@ header {
   }
 }
 
+.welcome-cards {
+
+  @include breakpoint(medium) {
+    display: flex;
+  }
+}
+
 .feed-content-list {
 
   .row {

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1453,7 +1453,7 @@ footer {
     float: right;
     line-height: $line-height * 2;
     margin-top: $line-height / 4;
-    padding: 0 $line-height / 2;
+    padding: 0 $line-height / 2 !important;
   }
 
   .comment-header {
@@ -1495,6 +1495,7 @@ footer {
     }
 
     .votes {
+      bottom: 12px !important;
       right: 12px !important;
     }
 

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -600,6 +600,7 @@ header {
     background: $light;
     border: 2px solid #fff;
     border-radius: rem-calc(12);
+    color: $text;
     height: 100%;
 
     &:hover {
@@ -679,6 +680,30 @@ header {
       right: -12px;
       position: absolute;
       top: -1px;
+    }
+  }
+
+  &.budget .description {
+    display: block;
+    max-height: $line-height * 5;
+    overflow: hidden;
+    padding: 0 $line-height / 2;
+    position: relative;
+
+    &::after {
+      background: linear-gradient(to bottom, rgba(255, 255, 255, 0), $light 50%);
+      bottom: 0;
+      content: "";
+      height: 24px;
+      left: 0;
+      position: absolute;
+      width: 100%;
+    }
+
+    p {
+      color: $text;
+      padding: 0;
+      text-align: left;
     }
   }
 }

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1415,7 +1415,6 @@ footer {
   }
 
   aside {
-    border-left: 2px solid $border;
 
     h3 {
       color: $label;

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2375,7 +2375,6 @@ table {
 
   @include breakpoint(medium) {
     float: right;
-    margin-top: rem-calc(-24);
   }
 
   label {

--- a/app/models/widget/feed.rb
+++ b/app/models/widget/feed.rb
@@ -35,6 +35,6 @@ class Widget::Feed < ApplicationRecord
   end
 
   def budgets
-    Budget.order("created_at DESC").limit(limit)
+    Budget.published.order("created_at DESC").limit(limit)
   end
 end

--- a/app/views/budgets/_budget.html.erb
+++ b/app/views/budgets/_budget.html.erb
@@ -1,7 +1,7 @@
 <% if budget.image.present? %>
 <div id="budget_heading"
      class="expanded budget with-background-image no-margin-top"
-     style="background-image: url(<%= asset_url budget.image.attachment.url(:large) %>);">
+     style="background-image: url(<%= asset_url budget.image.attachment.url(:original) %>);">
 <% else %>
 <div id="budget_heading" class="expanded budget no-margin-top">
 <% end %>

--- a/app/views/custom/welcome/_feeds.html.erb
+++ b/app/views/custom/welcome/_feeds.html.erb
@@ -91,7 +91,7 @@
                     <h4><%= item.current_phase.name %></h4>
                   <% end %>
                   <p class="dates"><%= item.start_date.to_date %> / <%= item.end_date.to_date %></p>
-                  <p class="description"><%= sanitize(item.description) %></p>
+                  <span class="description"><%= sanitize(item.description) %></span>
                   <p><%= t("welcome.feed.see_budget") %></p>
                 <% end %>
               </div>

--- a/app/views/custom/welcome/_feeds.html.erb
+++ b/app/views/custom/welcome/_feeds.html.erb
@@ -26,7 +26,7 @@
                 <% if item.image.present? %>
                   <div class="small-12 medium-6 large-3 column">
                     <div class="feed-image">
-                      <%= image_tag item.image_url(:thumb),
+                      <%= image_tag item.image_url(:medium),
                                     alt: item.image.title.unicode_normalize %>
                     </div>
                   </div>

--- a/app/views/legislation/annotations/_slim_version_chooser.html.erb
+++ b/app/views/legislation/annotations/_slim_version_chooser.html.erb
@@ -1,8 +1,9 @@
-<div class="row draft-chooser">
+<div id="draft" class="row draft-chooser">
   <div class="small-12 medium-6 column">
     <h3><%= t("legislation.annotations.version_chooser.seeing_version") %></h3>
     <div class="select-box">
-      <%= form_tag go_to_version_legislation_process_draft_versions_path(process), method: :get, id: "draft_version_go_to_version" do %>
+      <%= form_tag go_to_version_legislation_process_draft_versions_path(process, anchor: "draft"),
+                   method: :get, id: "draft_version_go_to_version" do %>
         <%= select_tag "draft_version_id", options_from_collection_for_select(process.draft_versions.published, "id", "display_title", draft_version.id), "aria-label": t("legislation.draft_versions.show.select_draft_version") %>
         <%= hidden_field_tag "redirect_action", "annotations" %>
         <%= submit_tag t("legislation.draft_versions.show.select_version_submit"), class: "button" %>

--- a/app/views/legislation/annotations/_version_chooser.html.erb
+++ b/app/views/legislation/annotations/_version_chooser.html.erb
@@ -1,8 +1,9 @@
-<div class="row draft-chooser">
+<div id="draft" class="row draft-chooser">
   <div class="small-12 medium-9 column">
     <h3><%= t(".seeing_version") %></h3>
     <div class="select-box">
-      <%= form_tag go_to_version_legislation_process_draft_versions_path(process), method: :get, id: "draft_version_go_to_version" do %>
+      <%= form_tag go_to_version_legislation_process_draft_versions_path(process, anchor: "draft"),
+                   method: :get, id: "draft_version_go_to_version" do %>
         <%= select_tag "draft_version_id", options_from_collection_for_select(process.draft_versions.published, "id", "display_title", draft_version.id), "aria-label": t("legislation.draft_versions.show.select_draft_version") %>
         <%= hidden_field_tag "redirect_action", "annotations" %>
         <%= submit_tag t("legislation.draft_versions.show.select_version_submit"), class: "button" %>

--- a/app/views/legislation/draft_versions/changes.html.erb
+++ b/app/views/legislation/draft_versions/changes.html.erb
@@ -8,11 +8,12 @@
 
 <div class="column row">
   <div class="draft-panels small-12 column row">
-    <div class="row draft-chooser">
+    <div id="draft" class="row draft-chooser">
       <div class="small-12 medium-9 column">
         <h3><%= t(".seeing_changelog_version") %></h3>
         <div class="select-box">
-          <%= form_tag go_to_version_legislation_process_draft_versions_path(@process), method: :get, id: "draft_version_go_to_version" do %>
+          <%= form_tag go_to_version_legislation_process_draft_versions_path(@process, anchor: "draft"),
+                       method: :get, id: "draft_version_go_to_version" do %>
             <%= select_tag "draft_version_id", options_from_collection_for_select(@draft_versions_list, "id", "display_title", @draft_version.id), "aria-label": t("legislation.draft_versions.show.select_draft_version") %>
             <%= hidden_field_tag "redirect_action", "changes" %>
             <%= submit_tag t("legislation.draft_versions.show.select_version_submit"), class: "button" %>

--- a/app/views/legislation/draft_versions/show.html.erb
+++ b/app/views/legislation/draft_versions/show.html.erb
@@ -8,11 +8,12 @@
 
 <div class="column row">
   <div class="draft-panels small-12 column row">
-    <div class="row draft-chooser">
+    <div id="draft" class="row draft-chooser">
       <div class="small-12 medium-9 column">
         <h3><%= t(".seeing_version") %></h3>
         <div class="select-box">
-          <%= form_tag go_to_version_legislation_process_draft_versions_path(@process), method: :get, id: "draft_version_go_to_version" do %>
+          <%= form_tag go_to_version_legislation_process_draft_versions_path(@process, anchor: "draft"),
+                       method: :get, id: "draft_version_go_to_version" do %>
             <%= select_tag "draft_version_id", options_from_collection_for_select(@draft_versions_list, "id", "display_title", @draft_version.id), "aria-label": t(".select_draft_version") %>
             <%= submit_tag t(".select_version_submit"), class: "button" %>
           <% end %>

--- a/app/views/legislation/questions/show.html.erb
+++ b/app/views/legislation/questions/show.html.erb
@@ -8,23 +8,25 @@
         <h4><%= link_to @process.title, @process %></h4>
       </div>
     </div>
-    <div class="small-12 medium-3 column">
-      <% if @question.next_question_id %>
-        <%= link_to legislation_process_question_path(@process, @question.next_question_id), class: "quiz-next-link" do %>
-          <%= content_tag :div, class: "quiz-next" do %>
-            <%= t(".next_question") %>
-            <span class="icon-angle-right" aria-hidden="true">
+    <% if @process.questions.count > 1 %>
+      <div class="small-12 medium-3 column">
+        <% if @question.next_question_id %>
+          <%= link_to legislation_process_question_path(@process, @question.next_question_id), class: "quiz-next-link" do %>
+            <%= content_tag :div, class: "quiz-next" do %>
+              <%= t(".next_question") %>
+              <span class="icon-angle-right" aria-hidden="true">
+            <% end %>
+          <% end %>
+        <% elsif @question.first_question_id %>
+          <%= link_to legislation_process_question_path(@process, @question.first_question_id), class: "quiz-next-link" do %>
+            <%= content_tag :div, class: "quiz-next" do %>
+              <%= t(".first_question") %>
+              <span class="icon-angle-right" aria-hidden="true">
+            <% end %>
           <% end %>
         <% end %>
-      <% elsif @question.first_question_id %>
-        <%= link_to legislation_process_question_path(@process, @question.first_question_id), class: "quiz-next-link" do %>
-          <%= content_tag :div, class: "quiz-next" do %>
-            <%= t(".first_question") %>
-            <span class="icon-angle-right" aria-hidden="true">
-          <% end %>
-        <% end %>
-      <% end %>
-    </div>
+      </div>
+    <% end %>
   </div>
   <div class="row">
     <div class="small-12 medium-9 column">

--- a/app/views/polls/questions/_question.html.erb
+++ b/app/views/polls/questions/_question.html.erb
@@ -1,5 +1,7 @@
 <div id="<%= dom_id(question) %>" class="poll-question">
-  <span class="question-list-label"><%= t("polls.question") %> <%= index + 1 %></span>
+  <% if @questions.count > 1 %>
+    <span class="question-list-label"><%= t("polls.question") %> <%= index + 1 %></span>
+  <% end %>
 
   <h3 class="inline-block">
     <%= question.title %>

--- a/app/views/welcome/_card.html.erb
+++ b/app/views/welcome/_card.html.erb
@@ -1,5 +1,5 @@
 <div id="<%= dom_id(card) %>"
-     class="card small-12 medium-<%= card.columns %> column margin-bottom end" data-equalizer-watch>
+     class="card small-12 medium-<%= card.columns %> column margin-bottom end">
   <%= link_to card.link_url do %>
     <figure class="figure-card">
       <div class="gradient"></div>

--- a/app/views/welcome/_cards.html.erb
+++ b/app/views/welcome/_cards.html.erb
@@ -1,6 +1,6 @@
 <h3 class="title"><%= t("welcome.cards.title") %></h3>
 
-<div class="row" data-equalizer data-equalizer-on="medium">
+<div class="row welcome-cards">
   <% @cards.each do |card| %>
     <%= render "card", card: card %>
   <% end %>

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -58,6 +58,7 @@ namespace :deploy do
   before "deploy:restart", "puma:smart_restart"
   before "deploy:restart", "delayed_job:restart"
 
+  before :finished, "execute_release_tasks"
   after :finished, "refresh_sitemap"
 
   desc "Deploys and runs the tasks needed to upgrade to a new release"

--- a/config/locales/custom/nl/activerecord.yml
+++ b/config/locales/custom/nl/activerecord.yml
@@ -98,7 +98,7 @@ nl:
         status_draft: "Concept"
         status_published: "Gepubliceerd"
       tag:
-        name: "Vul de naam van de categorie toe"
+        name: "Vul de naam van het onderwerp/label toe"
       topic:
         title: "Titel"
         description: "Bericht"

--- a/config/locales/custom/nl/admin.yml
+++ b/config/locales/custom/nl/admin.yml
@@ -13,6 +13,7 @@ nl:
       edit: "Bewerk"
       configure: "Configureren"
       delete: "Verwijder"
+      confirm_delete: "Are you sure? This action will delete %{resource_name} '%{name}' and can't be undone."
     banners:
       index:
         create: "Banner maken"
@@ -89,24 +90,35 @@ nl:
     budgets:
       index:
         title: "Burgerbegroting"
+        title_budget_type: "Participatory budget type"
+        new_button: "Create new budget"
         new_single_title_html: "<strong>Enkel </strong> budget"
         new_single_description: "Hier creëer je een proces met één groep, wijk of thema. Je hebt als het ware één zak geld. Bijvoorbeeld 25.000 euro voor de \"Oosterparkwijk\", of 10.000 voor cultuur."
+        new_single_button: "Create single heading budget"
         new_multiple_title_html: "<strong>Meervoudig</strong> budget"
         new_multiple_description: "Hier creëer je een proces met meerdere groepen, wijken of thema's. Je hebt als het ware meerdere zakken geld. Bijvoorbeeld 25.000 voor \"Oosterparkwijk\", 30.000 voor het \"Centrum\", 28.000 voor de \"Westerparkwijk\" en de hele stad. Of voor verschillende thema's zoals sport, cultuur of gezondheid."
+        new_multiple_button: "Create multiple headings budget"
         table_name: "Titel"
         table_phase: "Fase"
+        table_budget_type: "Budget Type"
+        table_budget_completed: "Completed"
         table_duration: "Periode"
         table_preview: "Preview"
+        admin_ballots: "Admin ballots"
         filters:
           all: "Alle"
           open: "Actief"
           finished: "Afgesloten"
+        delete: "Verwijderen"
+        help_block: "Participatory budgets allow citizens to propose and decide directly how to spend part of the budget, with monitoring and rigorous evaluation of proposals by the institution."
+        type_single: "Single heading"
+        type_multiple: "Multiple headings"
       new:
         title_single: "Nieuw enkel budget"
         title_multiple: "Nieuw meervoudig budget"
       edit:
         title: "Bewerk begroting"
-        drafting: 'Deze burgerbegroting is in concept. Alleen admins kunnen het bekijken. Wanneer het proces is gepubliceerd, is het zichtbaar voor alle gebruikers. Het is dan niet mogelijk het weer terug te zetten naar concept. Klik op “Publiceer” rechtsboven om de begroting te publiceren.'
+        drafting: "Deze burgerbegroting is in concept. Alleen admins kunnen het bekijken. Wanneer het proces is gepubliceerd, is het zichtbaar voor alle gebruikers. Het is dan niet mogelijk het weer terug te zetten naar concept. Klik op \"Publiceer\" rechtsboven om de begroting te publiceren."
         preview: "Preview"
         publish: "Publiceer"
         administrators:
@@ -118,6 +130,7 @@ nl:
         name_description: "Dit wordt de naam van je proces. Dit is straks zichtbaar op de site."
         main_call_to_action: "Call to action (optioneel)"
         main_call_to_action_description: "Deze knop verschijnt op de voorpagina van deze begroting. Een call to action moedigt de gebruiker aan om iets te doen, zoals een idee indienen, stemmen of meer leren over het proces."
+        image_description: "If an image is uplodaded it will be used as the banner on top of this participatory budget, otherwise the default color for budgets will be used."
         info:
           budget_settings: "Algemene instellingen"
           heading_settings: "Heading settings"
@@ -126,29 +139,72 @@ nl:
           staff_settings: "Voeg admins en beoordelaars toe"
           groups_and_headings_settings: "Instellingen voor  groepen en koppen"
         groups_and_headings:
+          edit_group: "Edit group %{name}"
+          delete_group: "Delete group %{name}"
           headings: "Koppen"
+          edit_heading: "Edit heading %{name}"
+          delete_heading: "Delete heading %{name}"
           max_number_headings: "Maximaal aantal rubrieken waarop een gebruiker kan stemmen:"
           add_group: "Groep toevoegen"
           add_heading: "Kop toevoegen"
+        image_description: "If an image is uplodaded it will be used as the banner on top of this participatory budget, otherwise the default color for budgets will be used."
+        duration: "Duration"
+        phase_content: "Edit content"
       winners:
         calculate: "Tel de stemmen"
+      shared:
+        timeline_budget: "Budget"
+        timeline_groups: "Groups"
+        timeline_headings: "Headings"
+        timeline_phases: "Phases"
+        resource_name: "the budget"
+      create:
+        button:
+          continue: "Continue to groups"
+      publish:
+        notice: "Participatory budget published successfully"
     budget_phases:
       edit:
+        title: "Edit phase"
         duration: "Duur fase"
         duration_description: "In deze periode is de fase actief."
         image_description: "Als je een afbeelding upload zal deze te zien in de header van de burgerbegroting. Wanneer je niks upload worden de standaard kleuren gebruikt."
         main_call_to_action: "Call to action (optioneel)"
         main_call_to_action_description: "Deze knop verschijnt op de voorpagina van deze begroting. Een call to action moedigt de gebruiker aan om iets te doen, zoals een idee indienen, stemmen of meer leren over het proces."
         phase_name_help_text: "Dit is de titel van de fase die gebruikers zullen zien in de header wanneer de fase actief is."
+      index:
+        help_block: "Participatory budgets have different phases. Here you can enable or disable phases and also customize each individual phase."
+        button:
+          continue: "Finalize"
     budget_groups:
+      index:
+        new_button: "Add new group"
+        single:
+          help_block: "Groups are meant to organize headings, since this budget will only contain one heading, the same name can be used because it will not appear anywhere. You can just continue with the next step."
+        multiple:
+          help_block: "Groups are meant to organize headings. After a group is created and it contais headings, it's possible to determine in how many headings a user can vote per group."
       max_votable_headings: "Maximaal aantal rubrieken waarop een gebruiker kan stemmen"
+      create:
+        button:
+          continue: "Continue to headings"
     budget_headings:
+      name: "Heading name"
       price: "Budget"
       population: "Populatie"
       allow_custom_content: "Contentblokken toestaan"
       form:
         population_info: "Het veld rubriek wordt gebruikt voor statistische doeleinden. Na afloop van de begroting kan worden weergegeven door welk percentage is gestemd. Het veld is optioneel, dus je kunt het leeg laten als het niet van toepassing is."
         content_blocks_info: "Als dit is aangevinkt, kun je op maat gemaakte content toevoegen. Via Instellingen Costum content blocks. Deze content zal dan verschijnen bij de ideeën pagina."
+      create:
+        button:
+          continue: "Continue to phases"
+      index:
+        showing_headings_from_group: "Currently showing headings from the group:"
+        new_button: "Add new heading"
+        single:
+          help_block: "Headings are meant to divide the money of the participatory budget. Since this budget will only contain one heading, this is the place where you stablish the money that will be spent in this participaroty budget."
+        multiple:
+          help_block: "Headings are meant to divide the money of the participatory budget. Here you can add headings for this group and assign the amount of money that will be used for each heading."
     polls:
       index:
         title: "Alle peilingen"
@@ -446,6 +502,9 @@ nl:
       actions: "Acties"
       moderated_content: "Deze inhoud is door de moderators gemarkeerd en verborgen. Controleer hier of dit klopt."
       delete: "Verwijder"
+      close_modal: "Close modal"
+      learn_more: "Learn more"
+      example_url: "https://consulproject.org"
     dashboard:
       index:
         title: "Admin"

--- a/config/locales/custom/nl/admin.yml
+++ b/config/locales/custom/nl/admin.yml
@@ -212,6 +212,7 @@ nl:
         create: "Maak peiling"
         name: "Titel peiling"
         dates: "Periode"
+        geozone_restricted: "Beperkt tot gebieden"
       show:
         questions_tab: "Vragen"
         questions_title: "Alle vragen"

--- a/config/locales/custom/nl/budgets.yml
+++ b/config/locales/custom/nl/budgets.yml
@@ -11,7 +11,7 @@ nl:
         voted_info_2: "Je kunt je stem altijd aanpassen tot deze fase wordt gesloten"
         back: "Ga terug de Burgerbegroting"
         amount_spent: "Uitgegeven"
-        remaining: "U heeft nog <span>%{amount}</span> te spenderen."
+        remaining: "Je kunt nog <span>%{amount}</span> spenderen"
         remove: "Verwijder keuze"
         zero: "Je hebt op geen enkel idee gestemd."
       reasons_for_not_balloting:
@@ -123,6 +123,8 @@ nl:
         project_unfeasible: "Dit idee is gemarkeerd als niet stembaar en gaat niet naar de stemronde"
         project_winner: "Gekozen idee"
         unfeasibility_explanation: "Uitleg over geschiktheid idee"
+        price_explanation: "Toelichting kosten"
+        votes: "Stemmen"
       form:
         title: "Deel een idee"
         map_location_instructions: "Klik op de kaart om de locatie aan te geven. Je kunt de kaart bewegen"
@@ -139,9 +141,9 @@ nl:
         give_support: "Steun"
         remove_support: "Steun verwijderen"
         supports:
-          zero: "nog geen likes"
-          one: "1 like"
-          other: "%{count} likes"
+          zero: "nog geen steun"
+          one: "1 steunbetuiging"
+          other: "%{count} steunbetuigingen"
         already_added: "Je hebt dit idee al toegevoegd"
         already_supported: "Je hebt al op dit idee gestemd. Deel het!"
         confirm_group:

--- a/config/locales/custom/nl/budgets.yml
+++ b/config/locales/custom/nl/budgets.yml
@@ -44,6 +44,7 @@ nl:
         different: "Maar... je kunt ieder idee slechts één keer steunen. En je steun is definitief."
         supported: "Tot nu toe heb je <strong>%{count} ideeën</strong> gesteund."
         supported_one: "Tot nu toe heb je <strong>1 idee</strong> gesteund."
+        supported_not_logged_in: "Log in to start <strong>supporting projects</strong>."
         time: "Je kunt nog tot %{phase_end_date} ideeën steunen."
         share: "Je kunt ideeën die je hebt gesteund delen op social media. Zo krijgen de ideeën meer aandacht én wellicht meer steun!"
         scrolling: "Blijf scrollen om alle ideeën te zien"
@@ -52,6 +53,10 @@ nl:
       not_selected_investment_proyects: "Niet voor stemmen geselecteerde ideeën bekijken"
       see_results: "Bekijk de uitslag"
       finished_budgets: "Afgeronde processen"
+      all_phases: "Participatory budgets phases"
+      next_phase: "Next phase"
+      prev_phase: "Previous phase"
+      current_phase: "Current phase"
     investments:
       index:
         by_heading: "Ideeën voor %{heading}"

--- a/config/locales/custom/nl/budgets.yml
+++ b/config/locales/custom/nl/budgets.yml
@@ -56,7 +56,6 @@ nl:
       all_phases: "Participatory budgets phases"
       next_phase: "Next phase"
       prev_phase: "Previous phase"
-      current_phase: "Current phase"
     investments:
       index:
         by_heading: "Ideeën voor %{heading}"

--- a/config/locales/custom/nl/budgets.yml
+++ b/config/locales/custom/nl/budgets.yml
@@ -15,7 +15,17 @@ nl:
         remove: "Verwijder keuze"
         zero: "Je hebt op geen enkel idee gestemd."
       reasons_for_not_balloting:
+        not_selected: "Op niet-geselecteerde ideeën kan niet worden gestemd"
         not_enough_money: "Je kunt dit geld nu niet meer besteden. Als je wilt kun je je stem altijd aanpassen tijdens de stemfase."
+        not_verified: "Alleen geverifieerde gebruikers kunnen op ideeën stemmen; %{verify_account}."
+        change_ballot: "Wijzig je stem"
+        no_ballots_allowed: "De selectieronde is voorbij"
+    groups:
+      show:
+        unfeasible_title: "Niet stembare ideeën"
+        unfeasible: "Bekijk niet stembare ideeën"
+        unselected_title: ""
+        unselected: "Zie ideeën niet geselecteerd voor de stemronde"
     phase:
       drafting: "Concept (niet publiekelijk zichtbaar)"
       informing: "Informatie"
@@ -53,9 +63,10 @@ nl:
       not_selected_investment_proyects: "Niet voor stemmen geselecteerde ideeën bekijken"
       see_results: "Bekijk de uitslag"
       finished_budgets: "Afgeronde processen"
-      all_phases: "Participatory budgets phases"
+      all_phases: "Wanneer gebeurt er wat?"
       next_phase: "Next phase"
       prev_phase: "Previous phase"
+      empty_budgets: "Er zijn geen budgetten"
     investments:
       index:
         by_heading: "Ideeën voor %{heading}"
@@ -94,6 +105,11 @@ nl:
         orders:
           confidence_score: "best beoordeeld"
         read_more: "Bekijk idee"
+        search_form:
+          placeholder: "Zoek ideeën..."
+        unfeasible: "Niet stembare ideeën"
+        unfeasible_text: "De Coöperatieve Wijkraad heeft alle ideeën bekeken die de afgelopen weken zijn verzameld. We hebben nagekeken of ze écht voor de wijk zijn en hebben onderzocht hoeveel geld het zou kosten om dit idee uit te voeren. Hieronder vind je alle ideeën waar niet op gestemd kan worden. We hebben uitgelegd aan de indiener van het idee waarom wij dat vinden. Sommige ideeën zijn gecombineerd met een ander idee, andere ideeën waren een suggestie. Sommige ideeën worden al uitgevoerd en met sommige indieners van ideeën hebben we helaas geen contact kunnen krijgen."
+        title: "Ideeën"
       show:
         title: "Idee"
         supports: "Steun"
@@ -102,6 +118,11 @@ nl:
         comments_tab: "Reacties"
         project_selected: "Dit idee <strong>is geselecteerd</strong> voor de stemfase."
         project_not_selected: "Dit idee is niet geselecteerd voor de stemfase."
+        price_explanation: "Uitleg van de prijs van het idee"
+        see_price_explanation: "Uitleg van de prijs van het idee"
+        project_unfeasible: "Dit idee is gemarkeerd als niet stembaar en gaat niet naar de stemronde"
+        project_winner: "Gekozen idee"
+        unfeasibility_explanation: "Uitleg over geschiktheid idee"
       form:
         title: "Deel een idee"
         map_location_instructions: "Klik op de kaart om de locatie aan te geven. Je kunt de kaart bewegen"
@@ -110,6 +131,8 @@ nl:
         tags_label: "Onderwerpen/labels"
         edit_permission: "Je moet zelf het idee hebben ingediend om het te kunnen bewerken."
         updated_notice: "Je idee is aangepast."
+        tag_category_label: "Categorieën"
+        tags_placeholder: "Voer de categorie in die je wilt gebruiken, gescheiden door kommas (',')"
       investment:
         price_title: "Prijs"
         support_title: "Stemmen"
@@ -119,13 +142,26 @@ nl:
           zero: "nog geen likes"
           one: "1 like"
           other: "%{count} likes"
+        already_added: "Je hebt dit idee al toegevoegd"
+        already_supported: "Je hebt al op dit idee gestemd. Deel het!"
+        confirm_group:
+          one: "Je kunt maar in %{count} gebied op ideeën stemmen. Als je verder gaat is dat definitief. Weet je het zeker?"
+          other: "Je kunt maar in %{count} gebied op ideeën stemmen. Als je verder gaat is dat definitief. Weet je het zeker?"
       header:
         check_ballot: "Bekijk mijn stemmen"
+        check_ballot_link: "Bekijk mijn stemmen"
         price: "Dit proces heeft een budget van"
+        change_ballot: "Als je je bedenkt kun je je stemmen in %{check_ballot} verwijderen en opnieuw beginnen."
+      share:
+        message: "Dit is een goed idee voor de Oosterparkwijk! Vanaf 18 november kan je stemmen op dit idee"
     show:
       see_all_investments: "Bekijk alle ideeën"
       investments_list: "Ideeën"
       see_results: "Bekijk de uitslag"
+      unfeasible: "Bekijk de niet stembare ideeën"
+      unfeasible_title: "Niet stembare ideeën"
+      unselected: "Bekijk de ideeën die niet geselecteerd zijn voor de stemronde"
+      unselected_title: "Ideeën die niet geselecteerd zijn voor de stemronde"
     executions:
       heading: "Mijlpalen burgerbegroting"
       heading_selection_title: "Per gebied"
@@ -139,6 +175,7 @@ nl:
     progress_bar:
       you_have_assigned: "Je hebt"
       assigned: "toegewezen"
+      available: "Beschikbare bedrag:"
     results:
       link: "De uitslag"
       investment_title: "Idee"
@@ -146,3 +183,9 @@ nl:
       investment_proyects: "Lijst van alle gekozen ideeën"
       unfeasible_investment_proyects: "Lijst van alle gekozen ideeën"
       not_selected_investment_proyects: "Lijst van alle ideeën niet geselecteerd voor stemming"
+      accepted: "Bevestig je stem:"
+      amount_available: "Beschikbare bedrag:"
+      heading: "De uitslag"
+      page_title: "De uitslag"
+      show_all_link: "Toon alle ideeën"
+      hide_discarded_link: "Verberg niet gekozen ideeën"

--- a/config/locales/custom/nl/devise.yml
+++ b/config/locales/custom/nl/devise.yml
@@ -2,7 +2,47 @@ nl:
   devise:
     mailer:
       confirmation_instructions:
-        subject: Bevestig je email
+        subject: "Bevestig je email"
+      reset_password_instructions:
+        subject: "Wachtwoord opnieuw instellen"
+      unlock_instructions:
+        subject: "Instructies voor ontgrendelen account"
     sessions:
       signed_in: "U bent aangemeld."
       signed_out: "U bent afgemeld."
+      already_signed_out: "Je bent afgemeld"
+    passwords:
+      send_instructions: "Je ontvangt via e-mail instructies hoe je jouw account kunt ontgrendelen."
+      send_paranoid_instructions: "Als je e-mailadres bij ons bekend is, ontvangt je via e-mail instructies hoe je jouw account kan ontgrendelen"
+      no_token: "Je kunt deze pagina niet benaderen zonder een \"wachtwoord reset e-mail\"."
+      updated: "Je wachtwoord is gewijzigd. Je bent aangemeld!"
+      updated_not_active: "Je wachtwoord is gewijzigd"
+    password_expired:
+      change_required: "Dit wachtwoord is helaas verlopen"
+      expire_password: "Dit wachtwoord is helaas verlopen"
+    confirmations:
+      confirmed: "Je account is geactiveerd"
+      send_instructions: "Je ontvangt via e-mail instructies om jouw account te activeren"
+      send_paranoid_instructions: "Als je e-mailadres bij ons bekend is, ontvangt je hierop instructies hoe je jouw account kunt activeren"
+    failure:
+      already_authenticated: "Je bent al aangemeld"
+      inactive: "Je account is nog niet geactiveerd"
+      locked: "Je account is vergrendeld"
+      last_attempt: "Je hebt nog één poging over voordat jouw account wordt geblokkeerd."
+      timeout: "Oeps! Je sessie is verlopen. Meld je opnieuw aan om verder te gaan"
+      unauthenticated: "Meld je aan om verder te gaan. Nog geen account? Maak deze eenvoudig aan via 'registreren'"
+      unconfirmed: "Je account is nog niet geactiveerd. Klik op de link in je e-mail om jouw account te activeren "
+    registrations:
+      destroyed: "Jammer dat je gaat! Je account is succesvol verwijderd. Wij hopen je nog een keer terug te zien"
+      signed_up: "Je bent inschreven"
+      signed_up_but_inactive: "Je bent geregistreerd. Je kon alleen niet automatisch aangemeld worden omdat jouw account nog niet geactiveerd is. Klik hiervoor op de link die naar jouw e-mailadres is verstuurd. Geen mail ontvangen? Neem dan contact op met cooperatieve.wijkraad@groningen.nl\r\n"
+      signed_up_but_locked: "Je bent geregistreerd. Je kon alleen niet automatisch aangemeld worden omdat jouw account geblokkeerd is. Neem hiervoor contact op met cooperatieve.wijkraad@groningen.nl"
+      signed_up_but_unconfirmed: "Je ontvangt via de e-mail instructies hoe je jouew account kunt activeren. Geen mail ontvangen? Neem dan contact op met cooperatieve.wijkraad@groningen.nl"
+      update_needs_confirmation: "U hebt uw e-mailadres succesvol gewijzigd, maar we moeten uw nieuwe mailadres nog verifiëren. Controleer uw e-mail en klik op de link in de mail om uw mailadres te verifiëren"
+      updated: "Jouw accountgegevens zijn opgeslagen"
+    unlocks:
+      send_instructions: "Je ontvangt via de e-mail instructies hoe je jouw uw account kunt ontgrendelen. Geen mail ontvangen? Neem dan contact op met cooperatieve.wijkraad@groningen.nl"
+      send_paranoid_instructions: "Als jouw e-mailadres bij ons bekend is, ontvangt je via de e-mail instructies hoe je jouw account kan ontgrendelen. Kom je niet verder? Neem dan contact op met cooperatieve.wijkraad@groningen.nl"
+      unlocked: "Je account is succesvol ontgrendeld. Je kunt jezelf weer aanmelden!"
+    omniauth_callbacks:
+      success: "Successvol aangemeld via %{kind}."

--- a/config/locales/custom/nl/devise_views.yml
+++ b/config/locales/custom/nl/devise_views.yml
@@ -50,3 +50,5 @@ nl:
     confirmations:
       new:
         title: "Stuur verificatie instructies opnieuw"
+      show:
+        submit: "Bevestig"

--- a/config/locales/custom/nl/devise_views.yml
+++ b/config/locales/custom/nl/devise_views.yml
@@ -23,6 +23,7 @@ nl:
       registrations:
         new:
           organization_name_label: "Naam van organisatie of collectief"
+          responsible_name_note: "Dit is de persoon die namens de vereniging of het collectief initiatieven indient"
     sessions:
       new:
         submit: "Aanmelden"
@@ -42,7 +43,10 @@ nl:
           username_label: "Gebruikersnaam"
           username_note: "De opgegeven naam zal zichtbaar zijn voor andere gebruikers"
         success:
-          title: "Verifieer je email adres"
-          instructions_1: "Bekijk je mailbox - we hebben een mail gestuurd met een link om je account te verifiëren. "
-          instructions_2: "Wanneer je je profiel hebt geverifieerd , kun je beginnen met participeren."
-          thank_you: "Bedankt voor het invullen van je gegevens. Om je aanmelding te voltooien moet je je mailadres verifiëren."
+          title: "Verifieer je e-mailadres"
+          instructions_1: "Bekijk je mailbox - we hebben een mail gestuurd met een link om je e-mailadres te verifiëren."
+          instructions_2: "Wanneer je dit hebt geverifieerd, kun je beginnen met participeren."
+          thank_you: "Bedankt voor het invullen van je gegevens. Om je aanmelding te voltooien moet je je e-mailadres verifiëren. "
+    confirmations:
+      new:
+        title: "Stuur verificatie instructies opnieuw"

--- a/config/locales/custom/nl/general.yml
+++ b/config/locales/custom/nl/general.yml
@@ -45,8 +45,6 @@ nl:
     new:
       form:
         submit_button: "Discussie starten"
-      info: "Dit is niet de plek om een initiatief in te dienen. Ga daarvoor naar %{info_link}"
-      info_link: "deze pagina"
       start_new: "Discussie starten"
     show:
       author: "Auteur"
@@ -94,6 +92,8 @@ nl:
       tags_instructions: "Je kunt dit voorstel een label geven. Je kunt je eigen categorie kiezen, of één van de bestaande"
       map_location_instructions: "Klik op de kaart om de locatie aan te geven. Je kunt de kaart bewegen"
       tags_placeholder: "Voeg de gewenste termen toe, gescheiden door een komma (,)"
+    shared:
+      confirm_support: "Are you sure? You will support the proposal \"%{proposal}\" and this action cannot be undone."
     index:
       start_proposal: "Nieuw initiatief indienen"
       proposals_lists: "Initiatieven"
@@ -146,6 +146,7 @@ nl:
       unfeasible: "Onhaalbaar"
       done: "Gerealiseerd"
   polls:
+    question: "Question"
     index:
       no_polls: "Geen peilingen"
       filters:
@@ -159,9 +160,11 @@ nl:
         help: "Hulp bij peilingen"
       section_footer:
         description: "Geef je mening over specifieke onderwerpen"
+      remaining: "Remaining <strong>%{days}</strong> to participate"
     show:
       cant_answer_not_logged_in: "Je moet %{signin} of je %{signup} om verder te gaan"
       comments_tab: "Reacties"
+      more_info_options: "More information about the options"
   comments:
     comment:
       author: "Auteur"
@@ -232,14 +235,17 @@ nl:
       title: "Doe mee in drie stappen"
       subtitle: ""
       step_1:
+        number: "1"
         title: "Aanmelden"
         description: "Gebruik Twitter, Facebook,Google, of jouw mailadres om in te loggen."
         link: "Meld je binnen vijf minuten aan"
       step_2:
+        number: "2"
         title: "Stem"
         description: "Deel en stem op ideeën voor de gemeente Groningen."
         link: "Bekijk wat er in de gemeente gebeurt"
       step_3:
+        number: "3"
         title: "Deel"
         description: "Blijf betrokken bij ideeën die jij belangrijk vindt en deel ze via social media."
         link: ""
@@ -289,6 +295,8 @@ nl:
       districts: "Gebied"
       categories: "Onderwerpen/Labels"
     translations:
+      select_language_prompt: "Choose language"
+      add_language: "Add language"
       remove_language: "Taal verwijderen"
       languages_in_use:
         zero: "0 Taalinstelling"
@@ -297,6 +305,8 @@ nl:
     print:
       print_button: "Afdrukken"
   links:
+    form:
+      cancel_button: "Cancel"
     nested_links:
       note: "Voeg relevante links toe"
       add_new_link: "Link toevoegen"

--- a/config/locales/custom/nl/general.yml
+++ b/config/locales/custom/nl/general.yml
@@ -16,16 +16,24 @@ nl:
       user_permission_proposal: "Nieuwe voorstellen inbrengen"
       user_permission_support_proposal: "Op voorstellen stemmen"
       user_permission_verify_info: "* Alleen voor inwoners in het gebied."
+      username_label: "Gebruikersnaam"
+      organization_responsible_name_placeholder: "Vertegenwoordiger van de organisatie of groep"
   debates:
     create:
       form:
         submit_button: "Discussie starten"
     form:
+      tags_instructions: "Voeg steekwoorden toe"
+      tags_label: "Steekwoorden"
       tags_placeholder: "Voeg de gewenste termen toe, gescheiden door een komma (,)"
     index:
       start_debate: "Discussie starten"
       recommendations:
         without_interests: "Volg initiatieven zodat wij"
+        disable: "Aanbevelingen voor discussies worden niet meer weergegeven als u ze negeert. U kunt ze weer inschakelen op de pagina 'Mijn account'"
+        without_results: "Er zijn geen discussies die aansluiten bij jouw interesses"
+        actions:
+          success: "Aanbevelingen voor discussies zijn nu uitgeschakeld voor dit account"
       search_results:
         one: " met de tekst <strong>'%{search_term}'</strong>"
         other: " met de tekst <strong>'%{search_term}'</strong>"
@@ -39,9 +47,14 @@ nl:
         help: "Hulp bij discussies"
       section_footer:
         title: "Hulp bij discussies"
+        description: "Start een discussie om je mening met anderen te delen over onderwerpen die jij belangrijk vindt."
         help_text_1: "Deel je mening over allerlei onderwerpen, kansen of knelpunten die jij belangrijk vindt."
         help_text_2: "Om een discussie te starten of om deel te nemen aan een discussie moet je je %{org}."
         help_text_link: "aanmelden"
+      title: "Discussies"
+      search_form:
+        title: "Zoek"
+        placeholder: "Zoek in discussies..."
     new:
       recommendations_title: "Advies bij het starten van een discussie"
       form:
@@ -50,12 +63,16 @@ nl:
     show:
       author: "Auteur"
       comments_title: "Reacties"
+    edit:
+      editing: "Discussie bewerken"
+      show_link: "Discussie bekijken"
   form:
     debate: "discussie"
     proposal: "initiatief"
     budget/investment: "idee"
     not_saved: "zorgden ervoor dat je %{resource} niet geplaatst kan worden. <br>Bekijk de rode tekst om te zien wat aangepast moet worden."
     budget/investment: "idee"
+    accept_terms: "Ik begrijp dat ik een idee indien voor de Oosterparkwijk"
   proposals:
     proposal:
       reason_for_supports_necessary: ""
@@ -63,6 +80,8 @@ nl:
       archived: "Dit voorstel is gearchiveerd."
       share:
         guide: "Nu kun je jouw voorstel delen zodat mensen hun steun kunnen betuigen."
+        view_proposal: "Bekijk mijn idee"
+        edit: "Deel het hieronder op social media"
       successful: "Dit voorstel heeft de benodigde likes."
       support: "Like"
       support_title: "Steun op dit voorstel"
@@ -86,13 +105,18 @@ nl:
         retired: "Voorstel ingetrokken"
         retired_warning: "Dit voorstel is ingetrokken."
         retired_warning_link_to_explanation: "Lees waarom."
+      improve_info: "Verbeter je campagne en krijg meer likes"
+      created: "Bedankt voor je idee!"
     form:
       proposal_summary_note: "(maximaal 200 karakters)"
+      proposal_video_url: "Video toevoegen"
       proposal_video_url_note: "Je kunt een link van een Youtube of Vimeo  video toevoegen"
       tags_label: "Onderwerpen/labels"
       tags_instructions: "Je kunt dit voorstel een label geven. Je kunt je eigen categorie kiezen, of één van de bestaande"
       map_location_instructions: "Klik op de kaart om de locatie aan te geven. Je kunt de kaart bewegen"
       tags_placeholder: "Voeg de gewenste termen toe, gescheiden door een komma (,)"
+      proposal_responsible_name: "Volledige naam van persoon die het idee indient"
+      proposal_text: "Uitgebreide omschrijving"
     shared:
       confirm_support: "Are you sure? You will support the proposal \"%{proposal}\" and this action cannot be undone."
     index:
@@ -113,6 +137,10 @@ nl:
         description: "Steun lokale of regionale initiatieven. BIj voldoende steun, wordt een referendum gehouden."
       recommendations:
         without_interests: "Volg een initiatief om op de hoogte te blijven"
+        without_results: "Er zijn geen ideeën die aan je interesses voldoen"
+        disable: "Aanbevelingen van ideeën worden niet meer weergegeven als u ze negeert. U kunt ze weer inschakelen op de pagina 'Mijn account'"
+        actions:
+          success: "Aanbevelingen voor ideeën zijn nu uitgeschakeld voor dit account"
       orders:
         confidence_score: "best beoordeeld"
         created_at: "nieuw"
@@ -121,12 +149,27 @@ nl:
       search_results:
         one: " met de tekst <strong>'%{search_term}'</strong>"
         other: " met de tekst <strong>'%{search_term}'</strong>"
+      search_form:
+        placeholder: "Zoek ideeën..."
+      title: "Initiatieven"
+      filter_topic:
+        one: " met onderwerp '%{topic}'"
+        other: " met onderwerp '%{topic}'"
     new:
       form:
-        submit_button: "Voorstel indienen"
+        submit_button: "Idee indienen"
       more_info: "Hoe werken initiatieven?"
       start_new: "Voorstel indienen"
       recommendations_title: "Advies bij het indienen  van een initiatief"
+      recommendation_one: "Vul alle informatie in die je wil vertellen over je idee"
+      recommendation_two: "Waarom is dit een goed idee?Wat wil je met dit idee?Is het eenmalig of voor een lange periode? Hoeveel geld is er voor nodig? Wie doet er mee? Wie organiseert het? Wie zijn fan van het idee? Wat is het? Met wat voor regels krijg je te maken? Wat kan er wel en wat kan er niet? Wat zijn de belangen? Wat heb je nodig?"
+      recommendation_three: "Ben je al wat verder met je idee? Een plan van aanpak en een begroting zijn belangrijke stappen in het maken van een plan. Ook een video, website of een plaatje of foto doen het altijd goed voor de likes! Bezoekers kunnen namelijk reageren op je idee. Ook kan je likes verzamelen. Let op: dit zijn nog geen stemmen."
+    create:
+      form:
+        submit_button: "Idee indienen"
+    edit:
+      editing: "Idee bewerken"
+      show_link: "Bekijk idee"
     show:
       author: "Auteur"
       comments_tab: "Reacties"
@@ -166,6 +209,7 @@ nl:
       cant_answer_not_logged_in: "Je moet %{signin} of je %{signup} om verder te gaan"
       comments_tab: "Reacties"
       more_info_options: "More information about the options"
+      info_menu: "Vragen?"
   comments:
     comment:
       author: "Auteur"
@@ -177,6 +221,7 @@ nl:
         one: "1 reactie (verbergen)"
         other: "%{count} reacties (verbergen)"
         zero: "Geen reacties"
+      user_deleted: "Deelnemer verwijderd"
   comments_helper:
     comments_title: "Reacties"
   users:
@@ -186,6 +231,7 @@ nl:
     show:
       comments: "Reacties"
       proposals: "Initiatieven"
+      budget_investments: "Ideeën"
       actions: "Acties"
       filters:
         follows:
@@ -194,10 +240,19 @@ nl:
         proposals:
           one: "1 Initiatief"
           other: "%{count} Initiatieven"
+        budget_investments:
+          one: "1 Idee"
+          other: "%{count} Ideeën"
+      delete_alert: "Weet je zeker dat je jouw idee wilt verwijderen? Dit kan niet ongedaan gemaakt worden."
+      deleted_budget_investment: "Het idee is verwijderd"
     proposals:
       draft: "Concept"
       published: "Gepubliceerd"
       retired: "Teruggetrokken"
+    direct_messages:
+      new:
+        signin: "Inloggen"
+        authenticate: "Je moet %{signin} of %{signup} om verder te gaan."
   layouts:
     header:
       collaborative_legislation: "Inspraak"
@@ -212,6 +267,14 @@ nl:
       moderation: "Modereren"
       valuation: "Evalueren"
       open_gov: "Open Overheid"
+      notification_item:
+        new_notifications:
+          one: "Je hebt een nieuwe melding"
+          other: "Je hebt %{count} nieuwe meldingen"
+        notifications: Notificaties
+        no_notifications: "Je hebt geen nieuwe meldingen"
+    admin:
+      watch_form_message: "Je hebt niet-opgeslagen wijzigingen. Verlaat de pagina?"
     footer:
       org_name: "Stem van Groningen"
       contact_title: "Neem contact met ons op"
@@ -237,6 +300,8 @@ nl:
       title: "Go back to the top of the page"
   votes:
     supports: "Steun"
+    budget_investments:
+      not_verified: "Alleen geverifieerde gebruikers mogen stemmen op ideeën; %{verify_account}."
   welcome:
     steps:
       title: "Doe mee in drie stappen"
@@ -311,6 +376,12 @@ nl:
         other: "%{count} Taalinstelling"
     print:
       print_button: "Afdrukken"
+    followable:
+      budget_investment:
+        create:
+          notice: "Je volgt nu dit idee.<br>We brengen je op de hoogte als er updates zijn."
+        destroy:
+          notice: "Je volgt dit idee niet meer.<br>Je zult geen updates over dit idee meer ontvangen."
   links:
     form:
       cancel_button: "Cancel"
@@ -414,3 +485,14 @@ nl:
       surveys: "Peilingen"
     subnav:
       surveys: "Peilingen"
+  related_content:
+    content_title:
+      proposal: "Initiatieven"
+      budget_investment: "Idee"
+  unauthorized:
+    default: "Je hebt geen toestemming deze pagina te bezoeken."
+    manage:
+      all: "Je hebt geen toestemming '%{action' op %{subject uit te voeren."
+  poll_questions:
+    show:
+      voted: "Je hebt %{answer} gestemd"

--- a/config/locales/custom/nl/general.yml
+++ b/config/locales/custom/nl/general.yml
@@ -190,7 +190,7 @@ nl:
       unfeasible: "Onhaalbaar"
       done: "Gerealiseerd"
   polls:
-    question: "Question"
+    question: "Vraag"
     index:
       no_polls: "Geen peilingen"
       filters:
@@ -204,11 +204,12 @@ nl:
         help: "Hulp bij peilingen"
       section_footer:
         description: "Geef je mening over specifieke onderwerpen"
-      remaining: "Remaining <strong>%{days}</strong> to participate"
+      remaining: "Deelname nog <strong>%{days}</strong> mogelijk"
     show:
       cant_answer_not_logged_in: "Je moet %{signin} of je %{signup} om verder te gaan"
+      cant_answer_wrong_geozone: "Deze peiling is niet actief voor jouw gebied"
       comments_tab: "Reacties"
-      more_info_options: "More information about the options"
+      more_info_options: "Meer informatie over de antwoordmogelijkheden"
       info_menu: "Vragen?"
   comments:
     comment:
@@ -329,6 +330,7 @@ nl:
         proposals: "Initiatieven"
         budgets: "Burgerbegroting"
       see_budget: "Bekijk burgerbegroting"
+      see_all_proposals: "Alle initiatieven"
     cards:
       title: "Uitgelicht"
   shared:
@@ -379,9 +381,14 @@ nl:
     followable:
       budget_investment:
         create:
-          notice: "Je volgt nu dit idee.<br>We brengen je op de hoogte als er updates zijn."
+          notice: "Je volgt nu dit idee!<br>We houden je via notificaties op de hoogte van alle wijzigingen."
         destroy:
           notice: "Je volgt dit idee niet meer.<br>Je zult geen updates over dit idee meer ontvangen."
+      proposal:
+        create:
+          notice: "Je volgt nu dit initiatieven!<br>We houden je via notificaties op de hoogte van alle wijzigingen."
+        destroy:
+          notice: "Je volgt dit initiatieven niet meer.<br>Je zult geen updates over dit initiatieven meer ontvangen."
   links:
     form:
       cancel_button: "Cancel"

--- a/config/locales/custom/nl/general.yml
+++ b/config/locales/custom/nl/general.yml
@@ -43,6 +43,7 @@ nl:
         help_text_2: "Om een discussie te starten of om deel te nemen aan een discussie moet je je %{org}."
         help_text_link: "aanmelden"
     new:
+      recommendations_title: "Advies bij het starten van een discussie"
       form:
         submit_button: "Discussie starten"
       start_new: "Discussie starten"
@@ -136,7 +137,7 @@ nl:
       motivation_2: "<strong>Wanneer je niet zo goed weet hoe je die campagne op moet zetten, kunnen wij je begeleiden. Je kunt er nu voor kiezen om eerst met onze hulp een campagne op te zetten en het concept van je initiatief op te slaan. Je kunt nu ook je initiatief direct publiceren op de website.</strong>"
       publish: "Nee, ik wil mijn initiatief direct publiceren"
       dashboard: "Ja, ik wil hulp en ik publiceer mijn initiatief later"
-      preview_title: "Dit is hoe je initiatief eruit ziet wanneer je het nu publiceert."
+      preview_title: "Dit is hoe je initiatief eruit ziet wanneer je het nu publiceert"
     notice:
       published: "Initiatief gepubliceerd"
     retire_form:
@@ -190,8 +191,13 @@ nl:
         follows:
           one: "1 Volgend"
           other: "%{count} Volgend"
+        proposals:
+          one: "1 Initiatief"
+          other: "%{count} Initiatieven"
     proposals:
       draft: "Concept"
+      published: "Gepubliceerd"
+      retired: "Teruggetrokken"
   layouts:
     header:
       collaborative_legislation: "Inspraak"
@@ -214,13 +220,14 @@ nl:
       facebook: "facebook/stemvangroningen"
     dashboard:
       proposal_header:
-        published: "Published"
+        published: "Gepubliceerd"
         draft: "Concept"
-        retired: "Retired"
+        retired: "Teruggetrokken"
       proposal_totals:
-        active_resources: "Actieve"
+        active_resources: "Actieve promotiemiddelen"
         community: "Deelnemers in community"
         preview_proposal: "Preview"
+        show_proposal: "Bekijk  initiatief"
         current_goal: "Huidige doel"
         supports:
           zero: "Geen steun"
@@ -280,8 +287,8 @@ nl:
     suggest:
       debate:
         found:
-          one: "Er bestaat al een discussie met de term '%{query}'. Je kunt deelnemen aan die discussie in plaats van een nieuwe discussie te delen."
-          other: "Er bestaan al discussies met de term '%{query}'. Je kunt deelnemen aan die discussies in plaats van een nieuwe discussie te delen."
+          one: "Er bestaat al een discussie met de term '%{query}'. Je kunt deelnemen aan die discussie in plaats van een nieuwe discussie te starten."
+          other: "Er bestaan al discussies met de term '%{query}'. Je kunt deelnemen aan die discussies in plaats van een nieuwe discussie te starten."
       budget_investment:
         message: "%{limit} van %{count} voorstellen met de term '%{query}'"
         found:
@@ -317,6 +324,7 @@ nl:
       polls: "Peilingen"
       messages: "Berichten naar gebruikers"
       related_content: "Gerelateerde inhoud"
+      resources: "Campagnemiddelen"
     progress:
       title: "Grafiek"
       group_by_month: "Maandelijks"
@@ -342,7 +350,7 @@ nl:
       comments: "Reacties"
     messages:
       send_notification: "Stuur berichten naar volgers van mijn initiatief"
-      previous_notifications: "Bekijk eerdere meldingen"
+      previous_notifications: "Bekijk eerdere berichten"
     polls:
       index:
         title: "Peilingen"
@@ -353,6 +361,7 @@ nl:
           other: "Je hebt %{count} peiling gecreëerd"
       new:
         title: "Nieuwe peiling"
+        submit: "Poll creëren"
       poll:
         responses:
           one: "%{count} reactie"
@@ -376,6 +385,8 @@ nl:
         send: "Verzenden naar %{address}"
       create:
         sent: "Mail verzonden"
+      new:
+        title: "E-mail om te delen"
   proposal_notifications:
     new:
       info_about_receivers: "Dit bericht wordt naar <strong>%{count} mensen</strong> gestuurd en is zichtbaar op de %{proposal_page}.<br> Berichten worden niet direct gestuurd, maar de gebruikers ontvangen periodiek een email met alle notificaties omtrent jouw initiatief."
@@ -398,3 +409,8 @@ nl:
   stats:
     index:
       comments: "Reacties"
+  communities:
+    show:
+      surveys: "Peilingen"
+    subnav:
+      surveys: "Peilingen"

--- a/config/locales/custom/nl/legislation.yml
+++ b/config/locales/custom/nl/legislation.yml
@@ -4,6 +4,9 @@ nl:
       header:
         active: "Actief"
         locked: "Gesloten"
+        coming_soon: "Coming soon"
+        published: "Published"
+        less_info: "Less information"
       proposals:
         empty_proposals: "Er zijn geen initiatieven"
         less_info: "Minder informatie"

--- a/config/locales/custom/nl/legislation.yml
+++ b/config/locales/custom/nl/legislation.yml
@@ -6,7 +6,7 @@ nl:
         locked: "Gesloten"
         coming_soon: "Coming soon"
         published: "Published"
-        less_info: "Less information"
+        less_info: "Minder informatie"
       proposals:
         empty_proposals: "Er zijn geen initiatieven"
         less_info: "Minder informatie"
@@ -30,14 +30,21 @@ nl:
         key_dates: "Activiteiten"
         debate_dates: "Discussies"
         allegations_dates: "Reacties"
+        proposals_dates: "Initiatieven"
       phase_empty:
         empty: "Nog niets gepubliceerd"
     annotations:
       index:
         title: "Reacties"
+        comments_count:
+          one: "%{count} reactie"
+          other: "%{count} reacties"
       comments:
         cancel: "Annuleren"
         publish_comment: "Publiceer reactie"
+        comments_count:
+          one: "%{count} reactie"
+          other: "%{count} reacties"
     draft_versions:
       show:
         seeing_version: "Je bekijkt nu"

--- a/config/locales/custom/nl/mailers.yml
+++ b/config/locales/custom/nl/mailers.yml
@@ -18,6 +18,7 @@ nl:
       share: "De Coöperatieve Wijkraad heeft alle ingediende ideeën bekeken, en gekeken hoeveel het ongeveer gaat kosten. Gefeliciteerd, jouw idee voor de Oosterparkwijk is haalbaar! Je kunt nu beginnen met je campagne. Deel je idee op social media en met je buren.<br>Veel succes!"
       share_button: "Deel je idee"
       sincerely: "Groeten van de Coöperatieve Wijkraad"
+      thanks: "Bedankt voor het meedoen."
     budget_investment_unfeasible:
       subject: "Helaas, je idee is onhaalbaar"
       hi: "Beste deelnemer,"
@@ -44,6 +45,7 @@ nl:
     direct_message_for_receiver:
       subject: "Je hebt een nieuw privébericht ontvangen"
       title: "Je hebt een nieuw privébericht ontvangen."
+      unsubscribe: "Als je geen directe boodschappen wilt ontvangen, kijk dan eens bij %{account en haal het vinkje weg bij 'ontvangen e-mails over directe berichten'."
     direct_message_for_sender:
       subject: "Je hebt een privébericht gestuurd"
       title_html: "Je hebt het volgende privébericht gestuurd naar <strong>%{receiver}</strong>:"
@@ -54,3 +56,9 @@ nl:
       button: "Schrijf je in"
       ignore: "Heb je deze uitnodiging ongevraagd ontvangen? Geen zorgen, dan kun je deze mail negeren.  "
       thanks: "Bedankt!"
+    email_verification:
+      subject: "Bevestig je e-mailadres"
+      title: "Bevestig je account door de volgende link te gebruiken"
+      thanks: "Bedankt!"
+      click_here_to_verify: "deze link"
+    no_reply: "Deze mail is verstuurd vanaf een emailadres waar niet op gereageerd kan worden."

--- a/config/locales/custom/nl/management.yml
+++ b/config/locales/custom/nl/management.yml
@@ -2,4 +2,15 @@ nl:
   management:
     budget_investments:
       edit: "Pas je idee aan."
-
+      create: "Nieuw idee"
+      filters:
+        unfeasible: "Onhaalbare ideeën"
+    budgets:
+      create_new_investment: "Nieuw idee"
+      print_investments: "Druk idee af"
+      support_investments: "Ideeën"
+    menu:
+      create_budget_investment: "Nieuw idee"
+      support_budget_investments: "Ideeënoverzicht"
+    permissions:
+      support_proposals: "Stem op ideeën"

--- a/config/locales/custom/nl/settings.yml
+++ b/config/locales/custom/nl/settings.yml
@@ -44,7 +44,7 @@ nl:
       poll_short_title_description: "Korte omschrijving van de peiling-functie, die verschijnt op de campagnepagina. Deze functie maakt het mogelijk voor gebruikers om een peiling bij hun initiatief te voegen."
       poll_description: "Uitgebreide omschrijving peiling."
       poll_description_description: "Deze uitgebreide omschrijvingen verschijnt op peiling-pagina van de campagnepagina."
-      poll_link: "Aanvullende informatie poll-functie"
+      poll_link: "Aanvullende informatie toevoegen peiling"
       poll_link_description: "Wanneer de peilingen-functie is geactiveerd op de campagnepagina kunnen admins een link toevoegen waarbij zij meer uitleg of aanvullende informatie geven over deze functie."
       email_short_title_description: 'Korte omschrijving van de email-functie, die verschijnt op de campagnepagina. De functie maakt het mogelijk voor gebruikers om emails te verzenden om hun initiatief te promoten. De content van de mail kun je hier vinden: "/app/views/dashboard/mailer/forward.html.erb"'
       email_description: "Uitgebreide omschrijving email"

--- a/lib/tasks/budgets.rake
+++ b/lib/tasks/budgets.rake
@@ -25,14 +25,7 @@ namespace :budgets do
   desc "Update existing budgets in drafting phase"
   task update_drafting_budgets: :environment do
     Budget.where(phase: "drafting").each do |budget|
-      if budget.phases.enabled.first.present?
-        next_enabled_phase = budget.phases.enabled.first.kind
-      else
-        next_enabled_phase = "informing"
-        budget.phases.informing.update!(enabled: true)
-      end
-      budget.update!(phase: next_enabled_phase)
-      budget.update!(published: false)
+      budget.update!(phase: "informing", published: false)
     end
   end
 end

--- a/lib/tasks/consul.rake
+++ b/lib/tasks/consul.rake
@@ -1,18 +1,16 @@
 namespace :consul do
   desc "Runs tasks needed to upgrade to the latest version"
-  task execute_release_tasks: ["settings:add_new_settings", "execute_release_1.2.0_tasks"]
+  task execute_release_tasks: ["settings:add_new_settings", "execute_release_1.1.0_tasks"]
 
   desc "Runs tasks needed to upgrade from 1.0.0 to 1.1.0"
   task "execute_release_1.1.0_tasks": [
     "budgets:set_original_heading_id",
     "migrations:valuation_taggings",
-    "migrations:budget_admins_and_valuators"
-  ]
-
-  desc "Runs tasks needed to upgrade from 1.1.0 to 1.2.0"
-  task "execute_release_1.2.0_tasks": [
     "budgets:update_drafting_budgets",
     "migrations:add_name_to_existing_budget_phases",
     "migrations:budget_phases_summary_to_description"
   ]
+
+  desc "Runs tasks needed to upgrade from 1.1.0 to 1.2.0"
+  task "execute_release_1.2.0_tasks": []
 end

--- a/lib/tasks/migrations.rake
+++ b/lib/tasks/migrations.rake
@@ -39,7 +39,7 @@ namespace :migrations do
       if phase.summary.present?
         phase.description << "<br>"
         phase.description << phase.summary
-        phase.save!
+        phase.update!(summary: nil) if phase.save
       end
     end
   end

--- a/lib/tasks/migrations.rake
+++ b/lib/tasks/migrations.rake
@@ -22,7 +22,12 @@ namespace :migrations do
   task add_name_to_existing_budget_phases: :environment do
     Budget::Phase::Translation.find_each do |translation|
       unless translation.name.present?
-        i18n_name = I18n.t("budgets.phase.#{translation.globalized_model.kind}", locale: translation.locale)
+        if I18n.available_locales.include? translation.locale
+          locale = translation.locale
+        else
+          locale = I18n.default_locale
+        end
+        i18n_name = I18n.t("budgets.phase.#{translation.globalized_model.kind}", locale: locale)
         translation.update!(name: i18n_name)
       end
     end

--- a/spec/features/custom/welcome_page_spec.rb
+++ b/spec/features/custom/welcome_page_spec.rb
@@ -2,8 +2,9 @@ require "rails_helper"
 
 describe "Welcome page" do
   context "Feeds" do
-    scenario "Show budgets info" do
+    scenario "Show published budgets info" do
       budget = create(:budget)
+      draft = create(:budget, :drafting, :informing)
 
       visit root_path
 
@@ -17,6 +18,9 @@ describe "Welcome page" do
         expect(page).to have_content budget.description
         expect(page).to have_content "See this budget"
         expect(page).to have_link href: budget_path(budget)
+        expect(page).not_to have_content draft.name
+        expect(page).not_to have_content draft.description
+        expect(page).not_to have_link href: budget_path(draft)
       end
     end
   end

--- a/spec/features/legislation/questions_spec.rb
+++ b/spec/features/legislation/questions_spec.rb
@@ -63,6 +63,17 @@ describe "Legislation" do
       expect(page).not_to have_content("Next question")
     end
 
+    scenario "do not show next question link with only one question" do
+      process_one_question = create(:legislation_process, debate_start_date: Date.current - 3.days,
+                                                          debate_end_date: Date.current + 2.days)
+      create(:legislation_question, process: process_one_question, title: "Question 1")
+
+      visit legislation_process_question_path(process_one_question, process_one_question.questions.first)
+
+      expect(page).to have_content("Question 1")
+      expect(page).not_to have_link("Next question")
+    end
+
     scenario "answer question" do
       question = process.questions.first
       create(:legislation_question_option, question: question, value: "Yes")

--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -184,6 +184,15 @@ describe "Polls" do
       expect(page).to have_content("Question 2 #{normal_question.title}", normalize_ws: true)
     end
 
+    scenario "Do not show question number in polls with one question" do
+      question = create(:poll_question, poll: poll)
+
+      visit poll_path(poll)
+
+      expect(page).to have_content question.title
+      expect(page).not_to have_content("Question 1")
+    end
+
     scenario "Question answers appear in the given order" do
       question = create(:poll_question, poll: poll)
       answer1 = create(:poll_question_answer, title: "First", question: question, given_order: 2)

--- a/spec/lib/tasks/budgets_spec.rb
+++ b/spec/lib/tasks/budgets_spec.rb
@@ -50,7 +50,7 @@ describe Budget do
     expect(budget.published).to be true
   end
 
-  it "changes the published attribut to false" do
+  it "changes the published attribute to false" do
     budget = create(:budget)
     budget.update_columns(phase: "drafting")
 

--- a/spec/lib/tasks/budgets_spec.rb
+++ b/spec/lib/tasks/budgets_spec.rb
@@ -62,23 +62,9 @@ describe Budget do
     expect(budget.published).to be false
   end
 
-  it "changes the phase to the first enabled phase" do
+  it "changes the phase to informing phase" do
     budget = create(:budget)
     budget.update_columns(phase: "drafting")
-    budget.phases.informing.update!(enabled: false)
-
-    expect(budget.phase).to eq "drafting"
-
-    run_update_drafting_budgets_task
-    budget.reload
-
-    expect(budget.phase).to eq "accepting"
-  end
-
-  it "enables and select the informing phase if there are not any enabled phases" do
-    budget = create(:budget)
-    budget.update_columns(phase: "drafting")
-    budget.phases.each { |phase| phase.update!(enabled: false) }
 
     expect(budget.phase).to eq "drafting"
 
@@ -86,6 +72,5 @@ describe Budget do
     budget.reload
 
     expect(budget.phase).to eq "informing"
-    expect(budget.phases.informing.enabled).to be true
   end
 end

--- a/spec/lib/tasks/migrations_spec.rb
+++ b/spec/lib/tasks/migrations_spec.rb
@@ -107,6 +107,7 @@ describe "Migration tasks" do
       budget_phase.reload
       expect(budget_phase.description_en).to eq "English description<br>English summary"
       expect(budget_phase.description_es).to eq "Spanish description"
+      expect(budget_phase.summary_en).to eq nil
     end
   end
 end


### PR DESCRIPTION
## Objectives

- Show only published budgets on homepage feed.
- Add new translations
- Simplify rake to update existing budgets in drafting phase
- Run all necessary tasks when deploying
- Use original image instead of large on budgets index header
- Move translations from database to custom yml files
- Fix budget_phases_summary_to_description migration 
- Disable scroll whell zoom on maps
- Use medium image size on welcome feeds
- Crop budget feed description on welcome page
- Fix sort by form position
- Fix legislation comments position
- Remove data equalizer on welcome cards
- Hide question number in polls with one question
- Hide next link in processes with one question
- Add anchor on legislation draft chooser

## Visual changes

**Crop budget feed description on welcome page**
![budget_welcome](https://user-images.githubusercontent.com/631897/87688100-d4ebf500-c786-11ea-9a1c-baf8bee4f65a.png)

**Fix sort by form position**
![sort_by_form](https://user-images.githubusercontent.com/631897/87688110-d74e4f00-c786-11ea-9116-2176a100fa40.png)
