### PR TITLE
Fix layout bugs

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1662,6 +1662,10 @@ footer {
         }
       }
     }
+
+    .participation-not-allowed {
+      position: relative;
+    }
   }
 
   a {

--- a/app/views/custom/welcome/_feeds.html.erb
+++ b/app/views/custom/welcome/_feeds.html.erb
@@ -91,7 +91,7 @@
                     <h4><%= item.current_phase.name %></h4>
                   <% end %>
                   <p class="dates"><%= item.start_date.to_date %> / <%= item.end_date.to_date %></p>
-                  <span class="description"><%= sanitize(item.description) %></span>
+                  <span class="description"><%= sanitize(strip_links(item.description)) %></span>
                   <p><%= t("welcome.feed.see_budget") %></p>
                 <% end %>
               </div>

--- a/spec/features/admin/homepage/homepage_spec.rb
+++ b/spec/features/admin/homepage/homepage_spec.rb
@@ -135,6 +135,27 @@ describe "Homepage" do
       end
     end
 
+    scenario "Budget phase do not show links on phase description", :js do
+      budget = create(:budget)
+
+      visit admin_homepage_path
+
+      within("#widget_feed_#{budgets_feed.id}") do
+        select "1", from: "widget_feed_limit"
+        click_button "Enable"
+      end
+
+      budget.current_phase.update!(description: "<p>Description of the phase with a link to "\
+                                                "<a href=\"https://consul.dev\">CONSUL website</a>.</p>")
+
+      visit root_path
+
+      within("#feed_budgets") do
+        expect(page).to have_content("Description of the phase with a link to CONSUL website")
+        expect(page).not_to have_link("CONSUL website")
+      end
+    end
+
     xscenario "Deactivate"
   end
 


### PR DESCRIPTION
## Objectives

- Fix participation not allowed message on comments.
- Remove budget phase description links on homepage cards.

## Visual Changes

### Message on comments before
![Screenshot 2020-08-03 at 12 20 10](https://user-images.githubusercontent.com/631897/89173015-e1908b80-d583-11ea-971d-43702d6dc28d.png)

### Message on comments after
![Screenshot 2020-08-03 at 11 41 49](https://user-images.githubusercontent.com/631897/89173021-e3f2e580-d583-11ea-8c5c-125431c9b6cd.png)

### Phase description before
![Screenshot 2020-08-03 at 12 20 26](https://user-images.githubusercontent.com/631897/89173035-e81f0300-d583-11ea-9769-576a5a8398ec.png)

### Phase description after
![Screenshot 2020-08-03 at 12 20 17](https://user-images.githubusercontent.com/631897/89173044-eb19f380-d583-11ea-89cd-ea53854963e4.png)
