### PR TITLE
Add custom recommendations text on budget investment new form

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1217,6 +1217,13 @@ footer {
   }
 }
 
+.budget-investment-new {
+
+  .recommendations li::before {
+    color: $brand-secondary;
+  }
+}
+
 // 5. Legislation
 // --------------------
 

--- a/app/views/budgets/investments/new.html.erb
+++ b/app/views/budgets/investments/new.html.erb
@@ -14,6 +14,15 @@
         </h2>
       <% end %>
     </div>
+
+    <h2 class="margin-top"><%= t("budgets.investments.new.recommendations_title") %></h2>
+    <ul class="recommendations">
+      <li><%= t("budgets.investments.new.recommendation_one") %></li>
+      <li><%= t("budgets.investments.new.recommendation_two") %></li>
+      <li><%= t("budgets.investments.new.recommendation_three") %></li>
+      <li><%= t("budgets.investments.new.recommendation_four") %></li>
+      <li><%= t("budgets.investments.new.recommendation_five") %></li>
+    </ul>
   </div>
 
   <div class="small-12 column">

--- a/config/locales/custom/en/budgets.yml
+++ b/config/locales/custom/en/budgets.yml
@@ -5,6 +5,13 @@ en:
         remove_support: "Remove your support"
       show:
         edit: "Edit"
+      new:
+        recommendations_title: "Describe the idea. Think for example of:"
+        recommendation_one: "Why is it a good idea?"
+        recommendation_two: "For whom is the idea meant (e.g. older people, young people, everyone)?"
+        recommendation_three: "Is it once-only (like an activity) or for several years (like a facility)?"
+        recommendation_four: "How much money do you think you will need for it? (optional, estimation is also fine)"
+        recommendation_five: "What would you like to do yourself for the realization of the idea?"
     ballots:
       show:
         back: "Go back to budgets"

--- a/config/locales/custom/nl/budgets.yml
+++ b/config/locales/custom/nl/budgets.yml
@@ -157,6 +157,13 @@ nl:
         change_ballot: "Als je je bedenkt kun je je stemmen in %{check_ballot} verwijderen en opnieuw beginnen."
       share:
         message: "Dit is een goed idee voor de Oosterparkwijk! Vanaf 18 november kan je stemmen op dit idee"
+      new:
+        recommendations_title: "Omschrijf het idee. Denk bijvoorbeeld aan:"
+        recommendation_one: "Waarom is het een goed idee?"
+        recommendation_two: "Voor wie is het idee bedoeld (bijvoorbeeld ouderen, jongeren, iedereen)?"
+        recommendation_three: "Is het eenmalig (zoals een activiteit) of voor meerdere jaren (zoals een voorziening)?"
+        recommendation_four: "Hoeveel geld denkt u dat ervoor nodig is (optioneel, een schatting is ook prima)?"
+        recommendation_five: "Wat zou u zelf willen doen voor de realisatie van het idee?"
     show:
       see_all_investments: "Bekijk alle ideeën"
       investments_list: "Ideeën"

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -898,6 +898,15 @@ describe "Budget Investments" do
 
       visit new_budget_investment_path(budget)
 
+      expect(page).to have_content("Describe the idea. Think for example of:")
+      expect(page).to have_content("Why is it a good idea?")
+      expect(page).to have_content("For whom is the idea meant (e.g. older people, young people, everyone)?")
+      expect(page).to have_content("Is it once-only (like an activity) or for several years "\
+                                   "(like a facility)?")
+      expect(page).to have_content("How much money do you think you will need for it? (optional, "\
+                                   "estimation is also fine)")
+      expect(page).to have_content("What would you like to do yourself for the realization of the idea?")
+
       expect(page).to have_content("#{heading.name} (#{budget.formatted_heading_price(heading)})")
 
       expect(page).to have_selector("input[name=\"budget_investment[heading_id]\"][value=\"#{heading.id}\"]",
@@ -932,6 +941,15 @@ describe "Budget Investments" do
       login_as(author)
 
       visit new_budget_investment_path(budget)
+
+      expect(page).to have_content("Describe the idea. Think for example of:")
+      expect(page).to have_content("Why is it a good idea?")
+      expect(page).to have_content("For whom is the idea meant (e.g. older people, young people, everyone)?")
+      expect(page).to have_content("Is it once-only (like an activity) or for several years "\
+                                   "(like a facility)?")
+      expect(page).to have_content("How much money do you think you will need for it? (optional, "\
+                                   "estimation is also fine)")
+      expect(page).to have_content("What would you like to do yourself for the realization of the idea?")
 
       expect(page).not_to have_content("#{heading.name} (#{budget.formatted_heading_price(heading)})")
 


### PR DESCRIPTION
## Objectives

Add custom recommendations text on budget investment new form.

## Visual Changes

<img width="1217" alt="recommendations" src="https://user-images.githubusercontent.com/631897/91036331-6f9de600-e607-11ea-80eb-8662a033ab6c.png">
