### PR TITLE
Budget custom content

### DIFF
--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -737,6 +737,7 @@
 .proposal,
 .investment-project,
 .budget-investment,
+.budget-investment-show,
 .legislation,
 .communities-show {
   margin: $line-height / 4 0;

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -238,9 +238,9 @@ class Budget < ApplicationRecord
 
   def investments_preview_list(limit = 9)
     case phase
-    when "accepting", "reviewing"
+    when "accepting", "reviewing", "selecting"
       investments.sample(limit)
-    when "selecting", "valuating", "publishing_prices"
+    when "valuating", "publishing_prices"
       investments.feasible.sample(limit)
     when "balloting", "reviewing_ballots"
       investments.selected.sample(limit)

--- a/app/views/budgets/investments/_investment_detail.erb
+++ b/app/views/budgets/investments/_investment_detail.erb
@@ -5,6 +5,9 @@
   <span class="bullet">&nbsp;&bull;&nbsp;</span>
   <%= l investment.created_at.to_date %>
   <span class="bullet">&nbsp;&bull;&nbsp;</span>
+  <span class="far fa-comments"></span>&nbsp;
+  <%= link_to t("shared.comments", count: investment.comments_count), "#comments" %>
+  <span class="bullet">&nbsp;&bull;&nbsp;</span>
   <%= investment.heading.name %>
   <span class="bullet">&nbsp;&bull;&nbsp;</span>
   <% if local_assigns[:preview].nil? %>

--- a/app/views/budgets/investments/_investment_info.html.erb
+++ b/app/views/budgets/investments/_investment_info.html.erb
@@ -1,4 +1,10 @@
 <p class="investment-project-info">
+  <span class="far fa-comments"></span>&nbsp;
+  <%= link_to t("shared.comments", count: investment.comments_count),
+              namespaced_budget_investment_path(investment, anchor: "comments") %>
+
+  <span class="bullet">&nbsp;&bull;&nbsp;</span>
+
   <% if investment.author.hidden? || investment.author.erased? %>
     <span class="author">
       <%= t("budgets.investments.show.author_deleted") %>

--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -41,14 +41,6 @@
           <div class="callout warning">
             <%= sanitize(t("budgets.investments.show.project_not_selected")) %>
           </div>
-        <% else %>
-          <br>
-          <div class="float-right">
-            <span class="label-budget-investment float-left">
-              <%= t("budgets.investments.show.title") %>
-            </span>
-            <span class="icon-budget"></span>
-          </div>
         <% end %>
         <% if investment.should_show_price? %>
           <div class="sidebar-divider"></div>

--- a/config/locales/custom/en/general.yml
+++ b/config/locales/custom/en/general.yml
@@ -68,6 +68,10 @@ en:
       vote_registered: "Your vote has been registered correctly."
   shared:
     expired: "Expired"
+    comments:
+      one: "1 comment"
+      other: "%{count} comments"
+      zero: "No comments"
   comments:
     delete_comment: "Delete comment"
     confirm_delete_comment: "Are you sure? This action will delete this comment. You can't undo this action."

--- a/config/locales/custom/nl/budgets.yml
+++ b/config/locales/custom/nl/budgets.yml
@@ -110,7 +110,6 @@ nl:
         unfeasible_text: "De Coöperatieve Wijkraad heeft alle ideeën bekeken die de afgelopen weken zijn verzameld. We hebben nagekeken of ze écht voor de wijk zijn en hebben onderzocht hoeveel geld het zou kosten om dit idee uit te voeren. Hieronder vind je alle ideeën waar niet op gestemd kan worden. We hebben uitgelegd aan de indiener van het idee waarom wij dat vinden. Sommige ideeën zijn gecombineerd met een ander idee, andere ideeën waren een suggestie. Sommige ideeën worden al uitgevoerd en met sommige indieners van ideeën hebben we helaas geen contact kunnen krijgen."
         title: "Ideeën"
       show:
-        title: "Idee"
         supports: "Steunen"
         location: "Locatie: <strong>%{location}</strong>"
         organization_name: "Idee ingediend door: <strong>%{name}</strong>"

--- a/config/locales/custom/nl/general.yml
+++ b/config/locales/custom/nl/general.yml
@@ -387,6 +387,10 @@ nl:
         zero: "0 Taalinstelling"
         one: "1 Taalinstelling"
         other: "%{count} Taalinstelling"
+    comments:
+      one: "1 opmerking"
+      other: "%{count} opmerkingen"
+      zero: "Geen reacties"
     print:
       print_button: "Afdrukken"
     followable:

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -132,7 +132,6 @@ en:
         location: "Location: <strong>%{location}</strong>"
         organization_name: "Proposed on behalf of: <strong>%{name}</strong>"
         share: Share
-        title: Investment project
         supports: Supports
         votes: Votes
         price: Price

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -85,6 +85,9 @@ describe "Budget Investments" do
     investments.each do |investment|
       within("#budget-investments") do
         expect(page).to have_content investment.title
+        expect(page).to have_content investment.comments_count
+        comments_link = budget_investment_path(budget, id: investment.id, anchor: "comments")
+        expect(page).to have_css("a[href=\"#{comments_link}\"]", text: "No comments")
         expect(page).to have_css("a[href='#{budget_investment_path(budget, id: investment.id)}']", text: investment.title)
         expect(page).not_to have_content(unfeasible_investment.title)
       end
@@ -1129,6 +1132,7 @@ describe "Budget Investments" do
     expect(page).to have_content(investment.title)
     expect(page).to have_content(investment.description)
     expect(page).to have_content(investment.author.name)
+    expect(page).to have_content(investment.comments_count)
     expect(page).to have_content(investment.heading.name)
     # Remove investment code
     # within("#investment_code") do

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -1349,6 +1349,7 @@ describe "Budget Investments" do
   end
 
   scenario "Show title (no message)" do
+    skip "Removed by custom content"
     investment = create(:budget_investment,
                         :feasible,
                         :finished,

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -400,8 +400,8 @@ describe Budget do
       expect(budget.investments_preview_list(3)).not_to eq budget.investments_preview_list(3)
     end
 
-    it "returns only feasible investments if phase is selecting, valuating or publishing_prices" do
-      %w[selecting valuating publishing_prices].each do |phase_name|
+    it "returns only feasible investments if phase is valuating or publishing_prices" do
+      %w[valuating publishing_prices].each do |phase_name|
         budget.phase = phase_name
 
         expect(budget.investments_preview_list.count).to be budget.investments.feasible.count


### PR DESCRIPTION
## Objectives

- Add comment count to investments.
- Remove sidebar investment title in the show view.
- Show any investments in the selecting phase: show a sample of any type of investment instead of showing only the feasible ones.