### PR TITLE
Show correct total number of supports in the budget view

### DIFF
--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -143,7 +143,9 @@ module BudgetsHelper
     end
   end
 
-  def budget_investments_total_supports(user)
-    Vote.where(votable_type: "Budget::Investment", voter_id: user.id).count
+  def budget_investments_total_supports(user, budget)
+    Vote.where(votable_type: "Budget::Investment",
+               votable_id: budget.investments.map(&:id),
+               voter_id: user.id).count
   end
 end

--- a/app/views/budgets/_supports_info.html.erb
+++ b/app/views/budgets/_supports_info.html.erb
@@ -13,11 +13,11 @@
     <div class="callout">
       <h3>
         <% if current_user %>
-          <% if budget_investments_total_supports(current_user) == 1 %>
+          <% total_supports = budget_investments_total_supports(current_user, budget) %>
+          <% if total_supports == 1 %>
             <%= sanitize(t("budgets.index.supports_info.supported_one")) %>
           <% else %>
-            <%= sanitize(t("budgets.index.supports_info.supported",
-                            count: budget_investments_total_supports(current_user))) %>
+            <%= sanitize(t("budgets.index.supports_info.supported", count: total_supports)) %>
           <% end %>
         <% else %>
           <%= sanitize(t("budgets.index.supports_info.supported_not_logged_in")) %>

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -531,6 +531,28 @@ describe "Budgets" do
 
       expect(page).to have_content "So far you supported 4 projects."
     end
+
+    scenario "Show supports only for current budget" do
+      voter = create(:user, :level_two)
+
+      first_budget = create(:budget, phase: "selecting")
+      first_group = create(:budget_group, budget: first_budget)
+      first_heading = create(:budget_heading, group: first_group)
+      create_list(:budget_investment, 2, :selected, heading: first_heading, voters: [voter])
+
+      second_budget = create(:budget, phase: "selecting")
+      second_group = create(:budget_group, budget: second_budget)
+      second_heading = create(:budget_heading, group: second_group)
+      create_list(:budget_investment, 3, :selected, heading: second_heading, voters: [voter])
+
+      login_as(voter)
+
+      visit budget_path(first_budget)
+      expect(page).to have_content "So far you supported 2 projects."
+
+      visit budget_path(second_budget)
+      expect(page).to have_content "So far you supported 3 projects."
+    end
   end
 
   context "In Drafting phase" do


### PR DESCRIPTION
## Objectives

BUG FIX

We were showing all the supports for all the budgets, now we only show the supports for the budget the user is viewing.
