### PR TITLE
Include only positive votes in the total of supports

### DIFF
--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -146,6 +146,7 @@ module BudgetsHelper
   def budget_investments_total_supports(user, budget)
     Vote.where(votable_type: "Budget::Investment",
                votable_id: budget.investments.map(&:id),
+               vote_flag: true,
                voter_id: user.id).count
   end
 end

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -553,6 +553,36 @@ describe "Budgets" do
       visit budget_path(second_budget)
       expect(page).to have_content "So far you supported 3 projects."
     end
+
+    scenario "Show supports only if the support has not been removed" do
+      voter = create(:user, :level_two)
+
+      budget = create(:budget, phase: "selecting")
+      group = create(:budget_group, budget: budget)
+      heading = create(:budget_heading, group: group)
+      investment = create(:budget_investment, :selected, heading: heading)
+
+      login_as(voter)
+
+      visit budget_path(budget)
+      expect(page).to have_content "So far you supported 0 projects."
+
+      visit budget_investment_path(budget, investment)
+      within("#budget_investment_#{investment.id}_votes") do
+        click_link "Support"
+        expect(page).to have_content "You have already supported this investment project."
+      end
+      visit budget_path(budget)
+      expect(page).to have_content "So far you supported 1 project."
+
+      visit budget_investment_path(budget, investment)
+      within("#budget_investment_#{investment.id}_votes") do
+        click_link "Remove your support"
+        expect(page).to have_content "No supports"
+      end
+      visit budget_path(budget)
+      expect(page).to have_content "So far you supported 0 projects."
+    end
   end
 
   context "In Drafting phase" do


### PR DESCRIPTION
## Objectives

Since we added the ability to remove a support, the vote was still in the database, but with a negative value. So we will only have into consideration positive votes to calculate the total amount of investments the user has supported.
