### PR TITLE
Do not resend confirmation email for already confirmed users

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -415,6 +415,10 @@ aside {
   color: $brand;
 }
 
+.callout a {
+  font-size: $small-font-size !important;
+}
+
 // 1. Header
 // --------------------
 

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,4 +1,19 @@
 class Users::ConfirmationsController < Devise::ConfirmationsController
+  # POST /resource/confirmation
+  def create
+    self.resource = resource_class.send_confirmation_instructions(resource_params)
+    yield resource if block_given?
+
+    if !self.resource.confirmation_required?
+      redirect_to new_user_confirmation_path,
+                  notice: WYSIWYGSanitizer.new.sanitize(t("devise.confirmations.user.already_confirmed"))
+    elsif successfully_sent?(resource)
+      respond_with({}, location: after_resending_confirmation_instructions_path_for(resource_name))
+    else
+      respond_with(resource)
+    end
+  end
+
   # new action, PATCH does not exist in the default Devise::ConfirmationsController
   # PATCH /resource/confirmation
   def update

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -13,7 +13,9 @@
     <%#= link_to t("devise_views.shared.links.new_password"), new_password_path(resource_name) %><!-- <br> -->
   <%# end -%>
 
-  <%- if devise_mapping.confirmable? && controller_name != "confirmations" %>
+  <% if controller_name == "passwords" %>
+    <%= sanitize(t("devise_views.shared.links.not_received")) %>
+  <%- elsif devise_mapping.confirmable? && controller_name != "confirmations" %>
     <%= sanitize(t("devise_views.shared.links.new_confirmation",
                     link: link_to(t("devise_views.shared.links.new_confirmation_link"),
                                   new_confirmation_path(resource_name)))) %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -119,6 +119,7 @@ ignore_missing:
   - "errors.messages.too_long"
   - "devise.failure.invalid"
   - "devise.registrations.destroyed"
+  - "devise.confirmations.user.already_confirmed"
   - "devise.password_expired.*"
   - "seeds.settings.*"
   - "mailers.budget_investment_unfeasible.contact"

--- a/config/locales/custom/en/devise_views.yml
+++ b/config/locales/custom/en/devise_views.yml
@@ -12,6 +12,7 @@ en:
       links:
         new_confirmation: "Haven't received instructions to activate your account? %{link}"
         new_confirmation_link: "Click here"
+        not_received: "Didn't receive a link in your mail? Maybe it came in your spam folder. Didn't it? Please contact <a href=\"mailto:destemvan@groningen.nl\">destemvan@groningen.nl</a>."
     confirmations:
       new:
         description: "Didn't receive a link? Maybe it ended up in your spam folder. You can use the button below to have the mail resent."

--- a/config/locales/custom/nl/devise.yml
+++ b/config/locales/custom/nl/devise.yml
@@ -23,7 +23,9 @@ nl:
     confirmations:
       confirmed: "Je account is geactiveerd"
       send_instructions: "Je ontvangt via e-mail instructies om jouw account te activeren"
-      send_paranoid_instructions: "Als je e-mailadres bij ons bekend is, ontvang je hierop instructies hoe je jouw account kunt activeren"
+      send_paranoid_instructions: "We hebben een nieuwe link verstuurd. Heb je niets ontvangen? Neem dan contact op met <a href=\"mailto:destemvan@groningen.nl\">destemvan@groningen.nl</a>"
+      user:
+        already_confirmed: "Je mailadres is al geverifieerd. Je kunt hiermee nu inloggen. Lukt dit niet? Neem dan contact op met <a href='mailto:destemvan@groningen.nl'>destemvan@groningen.nl</a>"
     failure:
       already_authenticated: "Je bent al aangemeld"
       inactive: "Je account is nog niet geactiveerd"

--- a/config/locales/custom/nl/devise.yml
+++ b/config/locales/custom/nl/devise.yml
@@ -25,7 +25,7 @@ nl:
       send_instructions: "Je ontvangt via e-mail instructies om jouw account te activeren"
       send_paranoid_instructions: "We hebben een nieuwe link verstuurd. Heb je niets ontvangen? Neem dan contact op met <a href=\"mailto:destemvan@groningen.nl\">destemvan@groningen.nl</a>"
       user:
-        already_confirmed: "Je mailadres is al geverifieerd. Je kunt hiermee nu inloggen. Lukt dit niet? Neem dan contact op met <a href='mailto:destemvan@groningen.nl'>destemvan@groningen.nl</a>"
+        already_confirmed: "Je mailadres is al geverifieerd. Je kunt hiermee nu inloggen. Lukt dit niet? Neem dan contact op met <a href=\"mailto:destemvan@groningen.nl\">destemvan@groningen.nl</a>"
     failure:
       already_authenticated: "Je bent al aangemeld"
       inactive: "Je account is nog niet geactiveerd"

--- a/config/locales/custom/nl/devise_views.yml
+++ b/config/locales/custom/nl/devise_views.yml
@@ -20,6 +20,7 @@ nl:
         new_confirmation: "Heb je geen link ontvangen in je mail? Misschien is deze in je spamfolder gekomen. Ook niet? %{link}."
         new_confirmation_link: "Klik dan hier"
         login: "Inloggen"
+        not_received: "Heb je geen link ontvangen in je mail? Misschien is deze in je spamfolder gekomen. Ook niet? Neem dan contact op met <a href=\"mailto:destemvan@groningen.nl\">destemvan@groningen.nl</a>."
     organizations:
       registrations:
         new:

--- a/config/locales/en/devise.yml
+++ b/config/locales/en/devise.yml
@@ -11,6 +11,8 @@ en:
       confirmed: "Your account has been confirmed."
       send_instructions: "In a few minutes you will receive an email containing instructions on how to reset your password."
       send_paranoid_instructions: "If your email address is in our database, in a few minutes you will receive an email containing instructions on how to reset your password."
+      user:
+        already_confirmed: "You have already confirmed your email account."
     failure:
       already_authenticated: "You are already signed in."
       inactive: "Your account has not yet been activated."

--- a/config/locales/es/devise.yml
+++ b/config/locales/es/devise.yml
@@ -11,6 +11,8 @@ es:
       confirmed: "Tu cuenta ha sido confirmada. Por favor autentifícate con tu red social o tu usuario y contraseña"
       send_instructions: "Recibirás un correo electrónico en unos minutos con instrucciones sobre cómo restablecer tu contraseña."
       send_paranoid_instructions: "Si tu correo electrónico existe en nuestra base de datos recibirás un correo electrónico en unos minutos con instrucciones sobre cómo restablecer tu contraseña."
+      user:
+        already_confirmed: "Tu cuenta ya ha sido confirmada."
     failure:
       already_authenticated: "Ya has iniciado sesión."
       inactive: "Tu cuenta aún no ha sido activada."

--- a/spec/features/users_auth_spec.rb
+++ b/spec/features/users_auth_spec.rb
@@ -408,6 +408,9 @@ describe "Users" do
     click_link "Sign in"
     click_link "Forgotten your password?"
 
+    expect(page).to have_content "Didn't receive a link in your mail? Maybe it came in your spam folder. "\
+                                 "Didn't it? Please contact destemvan@groningen.nl."
+
     fill_in "user_email", with: "manuela@consul.dev"
     click_button "Send instructions"
 

--- a/spec/features/users_auth_spec.rb
+++ b/spec/features/users_auth_spec.rb
@@ -438,7 +438,7 @@ describe "Users" do
   end
 
   scenario "Re-send confirmation instructions" do
-    create(:user, email: "manuela@consul.dev")
+    create(:user, email: "manuela@consul.dev", confirmed_at: nil)
 
     visit "/"
     click_link "Sign in"
@@ -465,6 +465,20 @@ describe "Users" do
     expect(page).to have_content "If your email address is in our database, in a few minutes you "\
                                  "will receive an email containing instructions on how to reset "\
                                  "your password."
+  end
+
+  scenario "Re-send confirmation instructions with already verified email" do
+    create(:user, email: "manuela@consul.dev")
+
+    visit "/"
+    click_link "Sign in"
+    expect(page).to have_content "Haven't received instructions to activate your account?"
+    click_link "Click here"
+
+    fill_in "user_email", with: "manuela@consul.dev"
+    click_button "Re-send instructions"
+
+    expect(page).to have_content "You have already confirmed your email account."
   end
 
   scenario "Sign in, admin with password expired" do


### PR DESCRIPTION
## Objectives

Do not resend confirmation instructions email for already confirmed users.
Instead, we will show an alert saying that the user is already confirmed.

## Visual Changes
<img width="971" alt="already_confirmed" src="https://user-images.githubusercontent.com/631897/95054529-4dad7e00-06f2-11eb-80e9-f99500717332.png">

