### PR TITLE
Remove heading name on unfeasible list

### DIFF
--- a/app/views/budgets/investments/index.html.erb
+++ b/app/views/budgets/investments/index.html.erb
@@ -42,7 +42,7 @@
 
       <% if @current_filter == "unfeasible" %>
         <div class="small-12 margin-bottom">
-          <h2><%= t("budgets.investments.index.unfeasible") %>: <%= @heading.name %></h2>
+          <h2><%= t("budgets.investments.index.unfeasible") %></h2>
         </div>
       <% elsif @heading.present? %>
         <div class="row">


### PR DESCRIPTION
## References

Using `@heading.name` was generating an `undefined method "name" for nil:NilClass` error when the `?heading_id?=` param was missing in the URL.

## Objectives

This PR removes duplicated `@heading.name` and only is render if the `@heading` param is present.

## Visual Changes

### Before
<img width="932" alt="before" src="https://user-images.githubusercontent.com/631897/95225225-d5cb7a80-07fb-11eb-8e31-2caa1e5cb11c.png">

### After
<img width="959" alt="after" src="https://user-images.githubusercontent.com/631897/95225240-da902e80-07fb-11eb-8b12-2eff7aff5464.png">
