### PR TITLE
Remove the delete image button on budget investment

### DIFF
--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -49,8 +49,4 @@ module BudgetInvestmentsHelper
   def investments_secondary_view
     investments_current_view == "default" ? "minimal" : "default"
   end
-
-  def show_author_actions?(investment)
-    can?(:edit, investment) || can_destroy_image?(investment)
-  end
 end

--- a/app/helpers/imageables_helper.rb
+++ b/app/helpers/imageables_helper.rb
@@ -1,8 +1,4 @@
 module ImageablesHelper
-  def can_destroy_image?(imageable)
-    imageable.image.present? && can?(:destroy, imageable.image)
-  end
-
   def imageable_max_file_size
     bytes_to_megabytes(Setting["uploads.images.max_size"].to_i.megabytes)
   end

--- a/app/views/budgets/investments/_author_actions.html.erb
+++ b/app/views/budgets/investments/_author_actions.html.erb
@@ -1,18 +1,7 @@
-<% if show_author_actions?(investment) %>
+<% if can?(:edit, investment) %>
   <div class="sidebar-divider"></div>
   <h2><%= t("budgets.investments.show.author") %></h2>
-  <div class="show-actions-menu">
-    <% if can?(:edit, investment) %>
-      <%= link_to t("budgets.investments.show.edit"),
-                  edit_budget_investment_path(investment.budget, investment),
-                  method: :get, class: "button hollow expanded" %>
-    <% else %>
-        <%= link_to image_path(investment.image),
-                    method: :delete,
-                    class: "button hollow alert expanded" do %>
-          <span class="icon-image"></span>
-          <%= t("images.remove_image") %>
-        <% end %>
-    <% end %>
-  </div>
+  <%= link_to t("budgets.investments.show.edit"),
+              edit_budget_investment_path(investment.budget, investment),
+              method: :get, class: "button hollow expanded" %>
 <% end %>

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -2056,7 +2056,7 @@ describe "Budget Investments" do
         end
       end
 
-      scenario "Contains remove image button in phases different from accepting" do
+      scenario "Do not show edit button in phases different from accepting" do
         budget.update!(phase: "reviewing")
         investment = create(:budget_investment, :with_image, heading: heading, author: author)
 
@@ -2064,9 +2064,8 @@ describe "Budget Investments" do
         visit budget_investment_path(budget, investment)
 
         within("aside") do
-          expect(page).to have_content "Author"
+          expect(page).not_to have_content "Author"
           expect(page).not_to have_link "Edit"
-          expect(page).to have_link "Remove image"
         end
       end
     end


### PR DESCRIPTION
## Objectives

- Remove the delete image button on budget investment.

## Visual Changes

**Before the user could remove the image in any phase, except `accepting phase`.**

<img width="310" alt="before" src="https://user-images.githubusercontent.com/631897/95388210-26bd9a80-08f2-11eb-8283-82b7c74132d4.png">

**Now the user only can edit the budget investment, including the image, during the `accepting phase`.**

<img width="293" alt="after" src="https://user-images.githubusercontent.com/631897/95388395-87e56e00-08f2-11eb-971d-582afb31782b.png">
