### PR TITLE
Count only positive supports on admin budget stats

### DIFF
--- a/app/controllers/admin/stats_controller.rb
+++ b/app/controllers/admin/stats_controller.rb
@@ -58,7 +58,7 @@ class Admin::StatsController < Admin::BaseController
     @budget = Budget.find(params[:budget_id])
     heading_ids = @budget.heading_ids
 
-    votes = Vote.where(votable_type: "Budget::Investment").
+    votes = Vote.where(votable_type: "Budget::Investment", vote_flag: true).
             includes(:budget_investment).
             where(budget_investments: { heading_id: heading_ids })
 

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -14,7 +14,6 @@ class StatsController < ApplicationController
     @debate_votes = daily_cache("debate_votes") { Vote.where(votable_type: "Debate").count }
     @proposal_votes = daily_cache("proposal_votes") { Vote.where(votable_type: "Proposal").count }
     @comment_votes = daily_cache("comment_votes") { Vote.where(votable_type: "Comment").count }
-    @investment_votes = daily_cache("budget_investment_votes") { Vote.where(votable_type: "Budget::Investment").count }
     @votes = daily_cache("votes") { Vote.count }
 
     @verified_users = daily_cache("verified_users") { User.with_hidden.level_two_or_three_verified.count }

--- a/spec/features/admin/stats_spec.rb
+++ b/spec/features/admin/stats_spec.rb
@@ -104,6 +104,9 @@ describe "Stats" do
 
         create(:budget_investment, heading: create(:budget_heading, group: group_2), voters: [create(:user)])
         create(:budget_investment, heading: heading_all_city, voters: [create(:user), create(:user)])
+        investment_retired_supports = create(:budget_investment, heading: heading_all_city)
+
+        3.times { create(:vote, votable: investment_retired_supports, vote_flag: false) }
 
         visit admin_stats_path
         click_link "Participatory Budgets"


### PR DESCRIPTION
## Objectives

The statistics of the budgets in the admin panel `/admin/stats/budget_supporting?budget_id=N` show the total supports number. 

This PR adds the `vote_flag: true` attribute to ignore withdrawn supports and remove unused `@investment_votes` in the stats controller.

