### PR TITLE
Show alert when try to delete budget with associated staff

### DIFF
--- a/app/controllers/admin/budgets_controller.rb
+++ b/app/controllers/admin/budgets_controller.rb
@@ -68,6 +68,8 @@ class Admin::BudgetsController < Admin::BaseController
       redirect_to admin_budgets_path, alert: t("admin.budgets.destroy.unable_notice")
     elsif @budget.poll.present?
       redirect_to admin_budgets_path, alert: t("admin.budgets.destroy.unable_notice_polls")
+    elsif @budget.budget_administrators.any? || @budget.budget_valuators.any?
+      redirect_to admin_budgets_path, alert: t("admin.budgets.destroy.unable_notice_staff")
     else
       @budget.destroy!
       redirect_to admin_budgets_path, notice: t("admin.budgets.destroy.success_notice")

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -146,6 +146,7 @@ en:
         success_notice: Budget deleted successfully
         unable_notice: You cannot delete a budget that has associated investments
         unable_notice_polls: You cannot delete a budget that has an associated poll
+        unable_notice_staff: "You cannot delete a budget that has administrators or valuators associated"
       new:
         title_single: New single heading budget
         title_multiple: New multiple headings budget

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -146,6 +146,7 @@ es:
         success_notice: Presupuesto eliminado correctamente
         unable_notice: No se puede eliminar un presupuesto con proyectos asociados
         unable_notice_polls: No se puede eliminar un presupuesto con una votación asociada
+        unable_notice_staff: "No se puede eliminar un presupuesto con administradores o evaluadores asociados"
       new:
         title_single: Nuevo presupuesto de partida única
         title_multiple: Nuevo presupuesto de múltiples partidas

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -427,6 +427,24 @@ describe "Admin budgets" do
       expect(page).to have_content("You cannot delete a budget that has an associated poll")
       expect(page).to have_content("There is 1 budget")
     end
+
+    scenario "Try to destroy a budget with administrators or valuators", :js do
+      admin = create(:administrator)
+      valuator = create(:valuator)
+
+      budget = create(:budget, administrators: [admin], valuators: [valuator])
+
+      visit admin_budgets_path
+
+      within "#budget_#{budget.id}" do
+        click_link "Delete budget"
+      end
+
+      accept_confirm
+
+      expect(page).to have_content("You cannot delete a budget that has administrators or valuators associated")
+      expect(page).to have_content(budget.name)
+    end
   end
 
   context "Edit" do


### PR DESCRIPTION
## Objectives

Now when an admin tries to delete a budget with administrators or valuators associated an error 500 is generated.

This PR adds an alert message instead of showing the error. 😌 

## Visual Changes
<img width="583" alt="delete_budget" src="https://user-images.githubusercontent.com/631897/98143243-269cc480-1ec9-11eb-82e9-7c5fcdf73283.png">
