### PR TITLE
Allow to delete a budget with staff assigned

### DIFF
--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -34,9 +34,9 @@ class Budget < ApplicationRecord
   has_many :headings, through: :groups
   has_many :lines, through: :ballots, class_name: "Budget::Ballot::Line"
   has_many :phases, class_name: "Budget::Phase"
-  has_many :budget_administrators
+  has_many :budget_administrators, dependent: :destroy
   has_many :administrators, through: :budget_administrators
-  has_many :budget_valuators
+  has_many :budget_valuators, dependent: :destroy
   has_many :valuators, through: :budget_valuators
 
   has_one :poll

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -427,6 +427,24 @@ describe "Admin budgets" do
       expect(page).to have_content("You cannot delete a budget that has an associated poll")
       expect(page).to have_content("There is 1 budget")
     end
+
+    scenario "Allow to delete a budget with administrators or valuators assigned", :js do
+      admin = create(:administrator)
+      valuator = create(:valuator)
+
+      budget = create(:budget, administrators: [admin], valuators: [valuator])
+
+      visit admin_budgets_path
+
+      within "#budget_#{budget.id}" do
+        click_link "Delete budget"
+      end
+
+      accept_confirm
+
+      expect(page).to have_content("Budget deleted successfully")
+      expect(page).not_to have_content(budget.name)
+    end
   end
 
   context "Edit" do


### PR DESCRIPTION
## Objectives

Now when an admin tries to delete a budget with administrators or valuators associated an error 500 is generated.

This PR allows deleting a budget with staff assigned. 😌 
