### PR TITLE
Fix share on whatsapp icon

### DIFF
--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -482,7 +482,6 @@
     display: inline-block;
     font-size: rem-calc(30);
     height: rem-calc(48);
-    padding-top: rem-calc(9);
     text-align: center;
     vertical-align: top;
     width: rem-calc(48);


### PR DESCRIPTION
## Objectives

Fix share on whatsapp icon position.

## Visual Changes

### BEFORE
<img width="445" alt="before" src="https://user-images.githubusercontent.com/631897/98668861-c686a200-2350-11eb-8bbd-8dac652d8d8d.png">

### AFTER
<img width="446" alt="after" src="https://user-images.githubusercontent.com/631897/98668915-dc946280-2350-11eb-8a16-82dc979676cf.png">
