### PR TITLE
Hide group name only on budgets with one group

### DIFF
--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -151,8 +151,12 @@ class Budget < ApplicationRecord
     current_phase&.balloting_or_later?
   end
 
+  def single_group?
+    groups.count == 1
+  end
+
   def single_heading?
-    groups.count == 1 && headings.count == 1
+    single_group? && headings.count == 1
   end
 
   def enabled_phases_amount

--- a/app/models/budget/group.rb
+++ b/app/models/budget/group.rb
@@ -30,10 +30,6 @@ class Budget
       all.sort_by(&:name)
     end
 
-    def single_heading_group?
-      headings.count == 1
-    end
-
     private
 
       def generate_slug?

--- a/app/models/budget/heading.rb
+++ b/app/models/budget/heading.rb
@@ -47,7 +47,7 @@ class Budget
     end
 
     def name_scoped_by_group
-      group.single_heading_group? ? name : "#{group.name}: #{name}"
+      budget.single_group? ? name : "#{group.name}: #{name}"
     end
 
     def can_be_deleted?

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -127,7 +127,7 @@ describe "Admin budget investments" do
       expect(page).to have_link("Change name")
       expect(page).to have_link("Plant trees")
 
-      select "Central Park", from: "heading_id"
+      select "Parks: Central Park", from: "heading_id"
       click_button "Filter"
 
       expect(page).not_to have_link("Realocate visitors")
@@ -1065,7 +1065,7 @@ describe "Admin budget investments" do
 
       fill_in "Title", with: "Potatoes"
       fill_in "Description", with: "Carrots"
-      select "#{budget_investment.group.name}: Barbate", from: "budget_investment[heading_id]"
+      select "Barbate", from: "budget_investment[heading_id]"
       uncheck "budget_investment_incompatible"
       check "budget_investment_selected"
 

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -938,8 +938,23 @@ describe "Budget Investments" do
       expect(page).to have_content "Build a skyscraper"
     end
 
+    scenario "Create with single group and multiple headings" do
+      budget = create(:budget)
+      group = create(:budget_group, name: "New group", budget: budget)
+      create(:budget_heading, budget: budget, group: group, name: "Culture")
+      create(:budget_heading, budget: budget, group: group, name: "Environment")
+
+      login_as(author)
+
+      visit new_budget_investment_path(budget)
+
+      expect(page).not_to have_content "New group"
+      select_options = find("#budget_investment_heading_id").all("option").map(&:text)
+      expect(select_options).to eq ["", "Culture", "Environment"]
+    end
+
     scenario "Create with multiple headings" do
-      heading2 = create(:budget_heading, budget: budget)
+      heading2 = create(:budget_heading, budget: budget, group: group)
       heading3 = create(:budget_heading, budget: budget)
       login_as(author)
 
@@ -962,7 +977,7 @@ describe "Budget Investments" do
         expect(page).to have_selector("option[value='#{heading3.id}']")
       end
 
-      select  heading2.name, from: "budget_investment_heading_id"
+      select "#{group.name}: #{heading2.name}", from: "budget_investment_heading_id"
       fill_in "Title", with: "Build a skyscraper"
       fill_in "Description", with: "I want to live in a high tower over the clouds"
       fill_in "budget_investment_location", with: "City center"
@@ -1115,7 +1130,7 @@ describe "Budget Investments" do
 
       select_options = find("#budget_investment_heading_id").all("option").map(&:text)
       expect(select_options).to eq ["",
-                                    "Toda la ciudad",
+                                    "Toda la ciudad: Toda la ciudad",
                                     "Health: More health professionals",
                                     "Health: More hospitals"]
     end

--- a/spec/features/management/budget_investments_spec.rb
+++ b/spec/features/management/budget_investments_spec.rb
@@ -386,7 +386,7 @@ describe "Budget Investments" do
         expect(page).to have_content(low_investment.title)
       end
 
-      select "Whole city: District Nine", from: "heading_id"
+      select "District Nine", from: "heading_id"
       click_button("Search")
 
       within "#budget-investments" do


### PR DESCRIPTION
## Objectives

In the form of creating a new investment was hiding the name of the group if it had only one heading, but could be confusing to users if there are, for example, five different groups of one heading.

## Visual Changes

The solution:

- **If the budget has one group and one heading, the heading selector is hidden.**

<img width="366" alt="single" src="https://user-images.githubusercontent.com/631897/98703773-2c3c5380-237c-11eb-86ff-2b27511f5e24.png">

- **If the budget has one group and more than one heading, the group name is hidden.**

<img width="603" alt="one_group" src="https://user-images.githubusercontent.com/631897/98703847-4413d780-237c-11eb-9feb-b8b344f1257a.png">

- **If the budget has more than one group, the group name appears regardless of the number of headings.**

<img width="612" alt="more_groups" src="https://user-images.githubusercontent.com/631897/98703875-4c6c1280-237c-11eb-9e0d-748b9a627e8d.png">
