### PR TITLE
Do not resize image depending on minimum height

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -2,11 +2,7 @@ class Image < ApplicationRecord
   include ImagesHelper
   include ImageablesHelper
 
-  has_attached_file :attachment, styles: {
-                                   large: "x#{Setting["uploads.images.min_height"]}",
-                                   medium: "300x300#",
-                                   thumb: "140x245#"
-                                 },
+  has_attached_file :attachment, styles: { large: "x475", medium: "300x300#", thumb: "140x245#" },
                                  url: "/system/:class/:prefix/:style/:hash.:extension",
                                  hash_data: ":class/:style",
                                  use_timestamp: false,


### PR DESCRIPTION
## Objectives

The minimum height will still be used for validation, but the image will not be resized depending on that value. The frontend layout is designed for images with a height of 475 pixels and changing this value will make the content not to look like it should.