### PR TITLE
 Hide group name with single heading on ballot

### DIFF
--- a/app/views/budgets/ballot/_ballot.html.erb
+++ b/app/views/budgets/ballot/_ballot.html.erb
@@ -23,7 +23,11 @@
       <div class="margin-top ballot-content">
         <div class="subtitle">
           <h3>
-            <%= group.name %> - <%= @ballot.heading_for_group(group).name %>
+            <% if group.headings.count > 1 %>
+              <%= group.name %> - <%= @ballot.heading_for_group(group).name %>
+            <% else %>
+              <%= @ballot.heading_for_group(group).name %>
+            <% end %>
           </h3>
           <%= link_to sanitize(t("budgets.ballots.show.remaining",
                       amount: @ballot.formatted_amount_available(@ballot.heading_for_group(group)))),

--- a/spec/features/budgets/ballots_spec.rb
+++ b/spec/features/budgets/ballots_spec.rb
@@ -380,7 +380,8 @@ describe "Ballots" do
       end
 
       within("#budget_group_#{group2.id}") do
-        expect(page).to have_content "#{group2.name} - #{heading2.name}"
+        expect(page).not_to have_content "#{group2.name}"
+        expect(page).to have_content "#{heading2.name}"
         expect(page).to have_content "Amount spent €15"
         expect(page).to have_content "You still have €35 to invest"
       end


### PR DESCRIPTION
## Objectives

Hide group name with single heading on ballot.

