### PR TITLE
Show correct budget ballot stats

### DIFF
--- a/app/controllers/admin/stats_controller.rb
+++ b/app/controllers/admin/stats_controller.rb
@@ -82,7 +82,12 @@ class Admin::StatsController < Admin::BaseController
 
     @vote_count_by_heading = @budget.lines.group(:heading_id).count.map { |k, v| [Budget::Heading.find(k).name, v] }.sort
 
-    @user_count_by_district = User.where.not(balloted_heading_id: nil).group(:balloted_heading_id).count.map { |k, v| [Budget::Heading.find(k).name, v] }.sort
+    @user_count_by_district = @budget.headings.map do |heading|
+      [
+        heading.name,
+        Budget::Ballot::Line.where(investment_id: heading.investments.map(&:id)).group(:ballot_id).count.count
+      ]
+    end
   end
 
   def polls

--- a/spec/system/admin/stats_spec.rb
+++ b/spec/system/admin/stats_spec.rb
@@ -221,6 +221,44 @@ describe "Stats" do
 
         expect(page).to have_content "Participants 2"
       end
+
+      scenario "Do not show headings from other budgets" do
+        other_heading = create(:budget_heading)
+        investment_2 = create(:budget_investment, :feasible, :selected, heading: other_heading)
+
+        create(:user, ballot_lines: [investment])
+        create(:user, ballot_lines: [investment_2])
+
+        visit admin_stats_path
+        click_link "Participatory Budgets"
+        within("#budget_#{budget.id}") do
+          click_link "Final voting"
+        end
+
+        expect(page).to have_content heading.name
+        expect(page).not_to have_content other_heading.name
+      end
+
+      scenario "Do not count removed votes" do
+        create(:user, ballot_lines: [investment])
+        create(:user, ballot_lines: [investment])
+
+        Budget::Ballot::Line.last.destroy!
+
+        visit admin_stats_path
+        click_link "Participatory Budgets"
+        within("#budget_#{budget.id}") do
+          click_link "Final voting"
+        end
+
+        within("#total_participants_count") do
+          expect(page).to have_content "1"
+        end
+
+        within("#user_count_#{heading.slug}") do
+          expect(page).to have_content "#{heading.name} 1"
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Objectives

- Show only votes for headings that belongs to the current budget.
- Do not count removed votes, so the participants count and the number of votes will be the same.