### PR TITLE
Require budget phases dates

### DIFF
--- a/app/models/budget/phase.rb
+++ b/app/models/budget/phase.rb
@@ -23,6 +23,8 @@ class Budget
     validates :budget, presence: true
     validates :kind, presence: true, uniqueness: { scope: :budget }, inclusion: { in: PHASE_KINDS }
     validates :main_button_url, presence: true, if: -> { main_button_text.present? }
+    validates :starts_at, presence: true
+    validates :ends_at, presence: true
     validate :invalid_dates_range?
 
     scope :enabled,           -> { where(enabled: true) }

--- a/spec/models/budget/phase_spec.rb
+++ b/spec/models/budget/phase_spec.rb
@@ -14,6 +14,18 @@ describe Budget::Phase do
       expect(build(:budget_phase, budget: nil)).not_to be_valid
     end
 
+    it "is not valid without a start date" do
+      phase = budget.phases.first
+      phase.starts_at = nil
+      expect(phase).not_to be_valid
+    end
+
+    it "is not valid without an end date" do
+      phase = budget.phases.first
+      phase.ends_at = nil
+      expect(phase).not_to be_valid
+    end
+
     describe "kind validations" do
       it "is not valid without a kind" do
         expect(build(:budget_phase, kind: nil)).not_to be_valid


### PR DESCRIPTION
## References

It was possible to edit an existing phase without a start or end date and it was causing the application to throw unexpected errors

## Objectives

Make both dates to be mandatory