### PR TITLE
Show task proposal title only if its present

### DIFF
--- a/app/views/admin/dashboard/administrator_tasks/index.html.erb
+++ b/app/views/admin/dashboard/administrator_tasks/index.html.erb
@@ -18,7 +18,11 @@
       <% @administrator_tasks.each do |task| %>
         <tr id="<%= dom_id(task) %>">
           <td>
-            <%= task.source.proposal.title %>
+            <% if task.source.proposal.present? %>
+              <%= task.source.proposal.title %>
+            <% else %>
+              <em><%= t("admin.dashboard.administrator_tasks.index.deleted_proposal") %></em>
+            <% end %>
           </td>
           <td>
             <%= task.source.action.title %>

--- a/config/locales/custom/nl/admin.yml
+++ b/config/locales/custom/nl/admin.yml
@@ -554,6 +554,7 @@ nl:
           filters:
             pending: "In afwachting"
             done: "Opgelost"
+          deleted_proposal: "Dit voorstel is verwijderd"
     stats:
       show:
         stats_title: "Statistieken"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -477,6 +477,7 @@ en:
           filters:
             pending: Pending
             done: Solved
+          deleted_proposal: "This proposal has been deleted"
         edit:
           back: Back to pending tasks list
           solving: Solve pending task

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -477,6 +477,7 @@ es:
           filters:
             pending: Pendientes
             done: Resueltos
+          deleted_proposal: "Esta propuesta ha sido eliminada"
         edit:
           back: Volver a la lista de tareas pendientes
           solving: Resolver tarea pendiente

--- a/spec/system/admin/dashboard/administrator_tasks_spec.rb
+++ b/spec/system/admin/dashboard/administrator_tasks_spec.rb
@@ -33,6 +33,15 @@ describe "Admin administrator tasks" do
       scenario "has a link that allows solving the request" do
         expect(page).to have_link("Solve")
       end
+
+      scenario "shows a message if proposal has been deleted" do
+        proposal = task.source.proposal
+        proposal.update!(hidden_at: Time.current)
+
+        visit admin_dashboard_administrator_tasks_path
+
+        expect(page).to have_content("This proposal has been deleted")
+      end
     end
   end
 


### PR DESCRIPTION
## Objectives

Show task proposal title only if its present to avoid an error if the proposal has been deleted.

