### PR TITLE
Custom content

### DIFF
--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -39,16 +39,25 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
 
   def update
     authorize! :admin_update, @investment
-    if @investment.update(budget_investment_params)
-      redirect_to admin_budget_budget_investment_path(@budget,
-                                                      @investment,
-                                                      Budget::Investment.filter_params(params).to_h),
-                  notice: t("flash.actions.update.budget_investment")
-    else
-      load_staff
-      load_valuator_groups
-      load_tags
-      render :edit
+
+    respond_to do |format|
+      format.html do
+        if @investment.update(budget_investment_params)
+          redirect_to admin_budget_budget_investment_path(@budget,
+                                                          @investment,
+                                                          Budget::Investment.filter_params(params).to_h),
+                      notice: t("flash.actions.update.budget_investment")
+        else
+          load_staff
+          load_valuator_groups
+          load_tags
+          render :edit
+        end
+      end
+
+      format.json do
+        @investment.update!(budget_investment_params)
+      end
     end
   end
 

--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -18,6 +18,7 @@ module Budgets
 
     before_action :load_ballot, only: [:index, :show]
     before_action :load_heading, only: [:index, :show]
+    before_action :load_assigned_heading, only: [:show]
     before_action :set_random_seed, only: :index
     before_action :load_categories, only: [:index, :new, :create, :edit, :update]
     before_action :load_budget_map, only: [:new, :edit]
@@ -152,6 +153,10 @@ module Budgets
           @assigned_heading = @ballot&.heading_for_group(@heading.group)
           load_map
         end
+      end
+
+      def load_assigned_heading
+        @assigned_heading = @ballot&.heading_for_group(@investment.heading.group)
       end
 
       def load_categories

--- a/app/models/administrator.rb
+++ b/app/models/administrator.rb
@@ -1,5 +1,8 @@
 class Administrator < ApplicationRecord
   belongs_to :user, touch: true
+
+  has_many :budget_administrators, dependent: :destroy
+
   delegate :name, :email, :name_and_email, to: :user
 
   validates :user_id, presence: true, uniqueness: true

--- a/app/models/valuator.rb
+++ b/app/models/valuator.rb
@@ -6,6 +6,7 @@ class Valuator < ApplicationRecord
 
   has_many :valuator_assignments, dependent: :destroy, class_name: "Budget::ValuatorAssignment"
   has_many :investments, through: :valuator_assignments, class_name: "Budget::Investment"
+  has_many :budget_valuators, dependent: :destroy
 
   validates :user_id, presence: true, uniqueness: true
 

--- a/app/models/widget/feed.rb
+++ b/app/models/widget/feed.rb
@@ -35,6 +35,6 @@ class Widget::Feed < ApplicationRecord
   end
 
   def budgets
-    Budget.published.order("created_at DESC").limit(limit)
+    Budget.open.published.order("created_at DESC").limit(limit)
   end
 end

--- a/app/views/admin/budget_investments/_select_investment.html.erb
+++ b/app/views/admin/budget_investments/_select_investment.html.erb
@@ -51,7 +51,7 @@
 </td>
 
 <td class="small text-center" data-field="visible_to_valuators">
-  <%= form_for [:admin, investment.budget, investment], remote: true do |f| %>
+  <%= form_for [:admin, investment.budget, investment], remote: true, format: :json do |f| %>
       <%= f.check_box :visible_to_valuators,
                       label: false,
                       class: "js-submit-on-change",

--- a/app/views/budgets/investments/_header.html.erb
+++ b/app/views/budgets/investments/_header.html.erb
@@ -4,7 +4,7 @@
 
       <div class="row">
         <div class="small-12 column">
-          <%= back_link_to budgets_path %>
+          <%= back_link_to budget_path(@budget) %>
 
           <% if can? :show, @ballot %>
             <%= link_to t("budgets.investments.header.check_ballot"),

--- a/app/views/budgets/results/show.html.erb
+++ b/app/views/budgets/results/show.html.erb
@@ -29,22 +29,26 @@
 <%= render "budgets/subnav", budget: @budget %>
 
 <div class="row">
-  <div class="small-12 medium-3 large-2 column">
-    <h3 class="margin-bottom">
-      <%= t("budgets.results.heading_selection_title") %>
-    </h3>
-    <ul id="headings" class="menu vertical no-margin-top no-padding-top">
-      <% @headings.each do |heading| %>
-        <li>
-          <%= link_to heading.name,
-                      budget_results_path(@budget, heading_id: heading.to_param),
-                      class: heading.to_param == @heading.to_param ? "is-active" : "" %>
-        </li>
-      <% end %>
-    </ul>
-  </div>
+  <% if @budget.single_heading? %>
+    <div class="small-12 column">
+  <% else %>
+    <div class="small-12 medium-3 large-2 column">
+      <h3 class="margin-bottom">
+        <%= t("budgets.results.heading_selection_title") %>
+      </h3>
+      <ul id="headings" class="menu vertical no-margin-top no-padding-top">
+        <% @headings.each do |heading| %>
+          <li>
+            <%= link_to heading.name,
+                        budget_results_path(@budget, heading_id: heading.to_param),
+                        class: heading.to_param == @heading.to_param ? "is-active" : "" %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
 
-  <div class="small-12 medium-9 large-10 column">
+    <div class="small-12 medium-9 large-10 column">
+  <% end %>
     <%= link_to t("budgets.results.show_all_link"), "#",
                 class: "js-toggle-link button hollow margin-bottom float-right-medium",
                 data: { "toggle-selector" => ".js-discarded",

--- a/app/views/legislation/questions/_answer_form.html.erb
+++ b/app/views/legislation/questions/_answer_form.html.erb
@@ -7,7 +7,7 @@
           <%= f.radio_button :legislation_question_option_id, question_option.id, label: false %>
           <span class="control-indicator"></span>
           <%= question_option.value %>
-        </label>
+        </label><br>
       <% end %>
       <%= f.submit t("legislation.questions.show.answer_question"), class: "button" %>
     <% end %>

--- a/config/locales/custom/nl/budgets.yml
+++ b/config/locales/custom/nl/budgets.yml
@@ -11,15 +11,33 @@ nl:
         voted_info_2: "Je kunt je stem altijd aanpassen tot deze fase wordt gesloten"
         back: "Ga terug de Burgerbegroting"
         amount_spent: "Uitgegeven"
+        amount_spent:
+          knapsack: "Uitgegeven <span>%{count}</span>"
+          approval:
+            zero: "Stemmen uitgebracht: <span>%{count}</span>"
+            one: "Stemmen uitgebracht: <span>%{count}</span>"
+            other: "Stemmen uitgebracht: <span>%{count}</span>"
         remaining: "Je kunt nog <span>%{amount}</span> spenderen"
         remove: "Verwijder keuze"
         zero: "Je hebt op geen enkel idee gestemd."
+        amount_limit:
+          knapsack: "%{count}"
+          approval:
+            one: "Je kan op <span>1</span> idee stemmen"
+            other: "Je kan op <span>%{count}</span> ideeën stemmen"
+        amount_available:
+          knapsack: "You still have <span>%{count}</span> to invest."
+          approval:
+            zero: "Je kan nog <span>%{count}</span> stemmen uitbrengen."
+            one: "Je kan nog <span>%{count}</span> stem uitbrengen."
+            other: "Je kan nog <span>%{count}</span> stemmen uitbrengen."
       reasons_for_not_balloting:
         not_selected: "Op niet-geselecteerde ideeën kan niet worden gestemd"
         not_enough_money: "Je kunt dit geld nu niet meer besteden. Als je wilt kun je je stem altijd aanpassen tijdens de stemfase."
         not_verified: "Alleen geverifieerde gebruikers kunnen op ideeën stemmen; %{verify_account}."
         change_ballot: "Wijzig je stem"
         no_ballots_allowed: "De selectieronde is voorbij"
+        different_heading_assigned: "Je hebt al gestemd in een andere groep: %{heading_link}"
     groups:
       show:
         unfeasible_title: "Niet stembare ideeën"
@@ -74,14 +92,20 @@ nl:
           voted:
             one: "Je hebt op <strong>1 idee</strong> gestemd die in totaal %{amount_spent} kosten."
             other: "Je hebt op <strong>%{count} ideeën</strong> gestemd die in totaal %{amount_spent} kosten."
-          voted_info: "Je kunt %{link} tot %{phase_end_date}. Het is niet verplicht al het budget te besteden."
+          voted_info:
+            knapsack:
+              one: "Je hebt op <strong>1 idee</strong> gestemd die in totaal %{amount_spent} kosten."
+              other: "Je hebt op <strong>%{count} ideeën</strong> gestemd die in totaal %{amount_spent} kosten."
+            approval:
+              one: "<strong>Je hebt op 1 idee gestemd</strong>"
+              other: "<strong>Je hebt op %{count} ideeën gestemd</strong>"
           voted_info_link: "je stem wijzigen"
           create: "Nieuw idee delen"
           zero: "Je hebt nog niet op een idee gestemd"
           by_feasibility: "Op haalbaarheid"
-          change_ballot: "Als u zich bedenkt kunt uw uw stemmen in %{check_ballot} verwijderen opnieuw beginnen."
-          check_ballot_link: "check mijn stemming"
-          different_heading_assigned_html: 'Je hebt al gestemd al op een ander deel van het budget: %{heading_link}'
+          change_ballot: "Als je je bedenkt kun je je stemmen in %{check_ballot} verwijderen en opnieuw beginnen."
+          check_ballot_link: "Bekijk mijn stemmen"
+          different_heading_assigned: "Je hebt al gestemd in een andere groep: %{heading_link}"
           feasible: "Haalbare budgetten ideeën"
           my_ballot: "Mijn stemmen"
           not_logged_in: "Om een idee in te dienen moet je %{sign_in} of %{sign_up}."
@@ -90,6 +114,10 @@ nl:
           unfeasible: "Onhaalbare ideeën"
           verified_only: "%{verify} je account om een idee in te dienen."
           verify_account: "je account verifieren"
+          change_vote_info:
+            knapsack: "Je kunt %{link} tot %{phase_end_date}. Het is niet verplicht al het budget te besteden."
+            approval: "Je kunt %{link} tot %{phase_end_date}."
+          change_vote_link: "je stem wijzigen"
         search_results:
           one: " met de tekst <strong>'%{search_term}'</strong>"
           other: " met de tekst <strong>'%{search_term}'</strong>"
@@ -144,15 +172,16 @@ nl:
           one: "1 steunbetuiging"
           other: "%{count} steunbetuigingen"
         already_added: "Je hebt dit idee al toegevoegd"
-        already_supported: "Je hebt al op dit idee gestemd. Deel het!"
+        already_supported: "Je hebt dit idee al gesteund. Deel het!"
         confirm_group:
-          one: "Je kunt maar in %{count} gebied op ideeën stemmen. Als je verder gaat is dat definitief. Weet je het zeker?"
-          other: "Je kunt maar in %{count} gebied op ideeën stemmen. Als je verder gaat is dat definitief. Weet je het zeker?"
+          one: "Je kunt ideeën in %{count} groep steunen. Als je verder gaat is dat definitief. Je kan dan niet meer in andere groepen steunen. Weet je dat zeker?"
+          other: "Je kunt ideeën in %{count} groep steunen. Als je verder gaat is dat definitief. Je kan dan niet meer in andere groepen steunen. Weet je dat zeker?"
       header:
         check_ballot: "Bekijk mijn stemmen"
         check_ballot_link: "Bekijk mijn stemmen"
         price: "Dit proces heeft een budget van"
         change_ballot: "Als je je bedenkt kun je je stemmen in %{check_ballot} verwijderen en opnieuw beginnen."
+        different_heading_assigned: "Je hebt al gestemd in een andere groep: %{heading_link}"
       share:
         message: "Dit is een goed idee voor de Groene Parel!"
       new:
@@ -184,6 +213,10 @@ nl:
       you_have_assigned: "Je hebt"
       assigned: "toegewezen"
       available: "Beschikbare bedrag:"
+      votes:
+        zero: "Je hebt op <strong>0</strong> van de <strong>%{limit}</strong> ideeën gestemd"
+        one: "Je hebt op <strong>1</strong> van de <strong>%{limit}</strong> ideeën gestemd"
+        other: "Je hebt op <strong>%{count}</strong> van de <strong>%{limit}</strong> ideeën gestemd"
     results:
       link: "De uitslag"
       investment_title: "Idee"

--- a/config/locales/custom/nl/devise_views.yml
+++ b/config/locales/custom/nl/devise_views.yml
@@ -28,6 +28,11 @@ nl:
           responsible_name_note: "Dit is de persoon die namens de vereniging of het collectief initiatieven indient"
           title: "Als organisatie of collectief registreren."
           submit: "Registreren"
+        success:
+          instructions_1: "Wij nemen zo snel mogelijk contact met je op om het collectief of de vereniging te verifiëren."
+          instructions_2: "We hebben een mail met een bevestigingslink gestuurd naar het opgegeven e-mailadres."
+          instructions_3: "Klik op de link om het account te bevestigen. Hierna kun je als collectief of vereniging meedoen op Stem van Groningen."
+          thank_you: "Bedankt voor het registreren als collectief of vereniging op de website."
     sessions:
       new:
         submit: "Inloggen"

--- a/config/locales/custom/nl/general.yml
+++ b/config/locales/custom/nl/general.yml
@@ -64,6 +64,7 @@ nl:
     show:
       author: "Auteur"
       comments_title: "Reacties"
+      edit_debate_link: "Bewerk"
     edit:
       editing: "Discussie bewerken"
       show_link: "Discussie bekijken"
@@ -313,6 +314,10 @@ nl:
     supports: "Steun"
     budget_investments:
       not_verified: "Alleen geverifieerde gebruikers mogen stemmen op ideeën; %{verify_account}."
+      different_heading_assigned:
+        one: "Je kan ideeën in %{count} groep steunen. Je hebt al ideeën gesteund in de groep %{supported_headings}."
+        other: "Je kan ideeën in %{count} groep steunen. Je hebt al ideeën gesteund in de groep %{supported_headings}."
+    organizations: "Collectieven en verenigingen kunnen niet stemmen."
   welcome:
     steps:
       title: "Doe mee in drie stappen"

--- a/config/locales/custom/nl/legislation.yml
+++ b/config/locales/custom/nl/legislation.yml
@@ -17,6 +17,7 @@ nl:
         section_footer:
           title: "Over plannen"
           description: "Help mee met het beoordelen en schrijven van plannen voorafgaand aan de totstandkoming van verordeningen, beleid en uitvoering. Jouw mening telt en heeft invloed."
+        empty_questions: "Er zijn geen discussies"
       index:
         filters:
           open: "Inspraak"
@@ -67,3 +68,32 @@ nl:
         debate_phase_not_open: "De discussie is gesloten en opmerkingen worden niet meer geaccepteerd."
         organizations: "Deelname van organisaties in discussies is niet toegestaan"
         unauthenticated: "Je dient %{signin} of %{signup} om deel te nemen."
+    summary:
+      title: "Samenvatting"
+      votes:
+        zero: "%{count} stemmen"
+        one: "%{count} stem"
+        other: "%{count} stemmen"
+      debate_phase: "Discussie fase"
+      proposals_phase: "Initiatief fase"
+      allegations_phase: "Reactie fase"
+      debates:
+        zero: "Geen discussies"
+        one: "%{count} discussie"
+        other: "%{count} discussies"
+      proposals:
+        zero: "Geen initiatieven"
+        one: "%{count} initiatief"
+        other: "%{count} initiatieven"
+      comments:
+        zero: "Geen reacties"
+        one: "%{count} reactie"
+        other: "%{count} reacties"
+      download: "Download samenvatting"
+      top_comments:
+        zero: "Geen reacties"
+        one: "%{count} reactie"
+        other: "Top reacties"
+      most_voted_comments: "Reacties met meeste stemmen"
+      no_allegation: "There are no comments"
+      process_empty: "This process didn't have any participation phases"

--- a/spec/controllers/admin/budget_investments_controller_spec.rb
+++ b/spec/controllers/admin/budget_investments_controller_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+describe Admin::BudgetInvestmentsController do
+  describe "PATCH update" do
+    it "does not redirect on AJAX requests" do
+      investment = create(:budget_investment)
+      sign_in(create(:administrator).user)
+
+      patch :update, params: {
+        id: investment,
+        budget_id: investment.budget,
+        format: :json,
+        budget_investment: { visible_to_valuators: true }
+      }
+
+      expect(response).not_to be_redirect
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.include RequestSpecHelper, type: :request
   config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::ControllerHelpers, type: :view
   config.include FactoryBot::Syntax::Methods
   config.include(EmailSpec::Helpers)
   config.include(EmailSpec::Matchers)

--- a/spec/system/admin/administrators_spec.rb
+++ b/spec/system/admin/administrators_spec.rb
@@ -49,6 +49,18 @@ describe "Admin administrators" do
     end
   end
 
+  scenario "Delete Administrator when it is assigned to a budget" do
+    create(:budget, administrators: [user_administrator])
+
+    within "#administrator_#{user_administrator.id}" do
+      click_on "Delete"
+    end
+
+    within("#administrators") do
+      expect(page).not_to have_content user_administrator.name
+    end
+  end
+
   context "Search" do
     let!(:administrator1) do
       create(:administrator, user: create(:user, username: "Bernard Sumner", email: "bernard@sumner.com"))

--- a/spec/system/admin/valuators_spec.rb
+++ b/spec/system/admin/valuators_spec.rb
@@ -54,11 +54,23 @@ describe "Admin valuators" do
     expect(page).not_to have_content "Can edit dossier"
   end
 
-  scenario "Destroy" do
-    click_link "Delete"
+  context "Destroy" do
+    scenario "Valuator not assigned to a budget" do
+      click_link "Delete"
 
-    within("#valuators") do
-      expect(page).not_to have_content(valuator.name)
+      within("#valuators") do
+        expect(page).not_to have_content(valuator.name)
+      end
+    end
+
+    scenario "Valuator assigned to a budget" do
+      create(:budget, valuators: [valuator])
+
+      click_link "Delete"
+
+      within("#valuators") do
+        expect(page).not_to have_content(valuator.name)
+      end
     end
   end
 

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -1697,6 +1697,22 @@ describe "Budget Investments" do
       expect(page).to have_content "€10,000"
     end
 
+    scenario "Show message if user already voted in other heading" do
+      group = create(:budget_group, budget: budget, name: "Global Group")
+      heading = create(:budget_heading, group: group, name: "Heading 1")
+      investment = create(:budget_investment, :selected, heading: heading)
+      heading2 = create(:budget_heading, group: group, name: "Heading 2")
+      investment2 = create(:budget_investment, :selected, heading: heading2)
+      user = create(:user, :level_two, ballot_lines: [investment])
+
+      login_as(user)
+      visit budget_investment_path(budget, investment2)
+
+      expect(page).to have_selector(".participation-not-allowed",
+                                    text: "You have already voted a different heading: Heading 1",
+                                    visible: false)
+    end
+
     scenario "Sidebar in show should display vote text" do
       investment = create(:budget_investment, :selected, budget: budget)
       visit budget_investment_path(budget, investment)

--- a/spec/system/budgets/results_spec.rb
+++ b/spec/system/budgets/results_spec.rb
@@ -82,9 +82,24 @@ describe "Results" do
   end
 
   scenario "Loads budget and heading by slug" do
+    other_heading = create(:budget_heading, group: group, price: 1000)
+    create(:budget_investment, :selected, heading: other_heading, price: 600, ballot_lines_count: 600)
+
     visit budget_results_path(budget.slug, heading_id: heading.slug)
 
+    expect(page).to have_content("By district")
     expect(page).to have_selector("a.is-active", text: heading.name)
+
+    within("#budget-investments-compatible") do
+      expect(page).to have_content investment1.title
+    end
+  end
+
+  scenario "Do not show headings sidebar on single heading budgets" do
+    visit budget_results_path(budget.slug, heading_id: heading.slug)
+
+    expect(page).not_to have_content("By district")
+    expect(page).not_to have_selector("a.is-active", text: heading.name)
 
     within("#budget-investments-compatible") do
       expect(page).to have_content investment1.title

--- a/spec/system/custom/welcome_page_spec.rb
+++ b/spec/system/custom/welcome_page_spec.rb
@@ -2,9 +2,11 @@ require "rails_helper"
 
 describe "Welcome page" do
   context "Feeds" do
-    scenario "Show published budgets info" do
-      budget = create(:budget)
-      draft = create(:budget, :drafting, :informing)
+    scenario "Show open published budgets info" do
+      budget = create(:budget, :accepting)
+      finished = create(:budget, :finished)
+      draft = create(:budget, :drafting)
+      draft.current_phase.update!(description: "Budget in draft mode")
 
       visit root_path
 
@@ -21,6 +23,9 @@ describe "Welcome page" do
         expect(page).not_to have_content draft.name
         expect(page).not_to have_content draft.description
         expect(page).not_to have_link href: budget_path(draft)
+        expect(page).not_to have_content finished.name
+        expect(page).not_to have_content finished.description
+        expect(page).not_to have_link href: budget_path(finished)
       end
     end
   end

--- a/spec/views/admin/budget_investments/select_investment_spec.rb
+++ b/spec/views/admin/budget_investments/select_investment_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe "investment row" do
+  it "uses a JSON request to update visible to valuators" do
+    investment = create(:budget_investment)
+    @budget = investment.budget
+    sign_in(create(:administrator).user)
+
+    render "admin/budget_investments/select_investment", investment: investment
+
+    expect(rendered).to have_css "form[action$='json'] input[name$='[visible_to_valuators]']"
+  end
+end


### PR DESCRIPTION
## Objectives

- Add custom translations.
- Replace back link on investments header.
- Add br tag for legislation questions answers.
- Hide sidebar results for single heading budgets.
- Don't redirect when toggling visible to valuators.
- Allow to delete valuators that are assigned to budgets.
- Allow to delete administrators that are assigned to budgets.
- Show only open published budgets on homepage cards.
- Show assigned heading on investment show.