### PR TITLE
Support different heading if other supports were removed

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -177,7 +177,7 @@ class User < ApplicationRecord
   end
 
   def voted_in_group?(group)
-    votes.for_budget_investments(Budget::Investment.where(group: group)).exists?
+    votes.up.for_budget_investments(Budget::Investment.where(group: group)).exists?
   end
 
   def headings_voted_within_group(group)
@@ -185,7 +185,7 @@ class User < ApplicationRecord
   end
 
   def voted_investments
-    Budget::Investment.where(id: votes.for_budget_investments.pluck(:votable_id))
+    Budget::Investment.where(id: votes.up.for_budget_investments.pluck(:votable_id))
   end
 
   def administrator?

--- a/spec/system/budgets/votes_spec.rb
+++ b/spec/system/budgets/votes_spec.rb
@@ -103,6 +103,35 @@ describe "Votes" do
       end
     end
 
+    scenario "Supporting in different heading if support was removed", :js do
+      other_heading = create(:budget_heading, group: group)
+
+      investment = create(:budget_investment, heading: heading)
+      other_investment = create(:budget_investment, heading: other_heading)
+
+      visit budget_investment_path(budget, investment)
+      accept_confirm { find(".in-favor a").click }
+      expect(page).to have_content "1 support"
+      expect(page).to have_content "You have already supported this investment project. Share it!"
+
+      visit budget_investment_path(budget, other_investment)
+      find(".in-favor a").click
+      expect(page).to have_content "You can only support investment projects in 1 district. "\
+                                   "You have already supported investments in"
+
+      visit budget_investment_path(budget, investment)
+      within("aside") do
+        expect(page).to have_content "1 support"
+        click_link "Remove your support"
+      end
+      expect(page).to have_content "No supports"
+
+      visit budget_investment_path(budget, other_investment)
+      accept_confirm { find(".in-favor a").click }
+      expect(page).to have_content "1 support"
+      expect(page).to have_content "You have already supported this investment project. Share it!"
+    end
+
     context "Voting in multiple headings of a single group" do
       let(:new_york) { heading }
       let(:san_francisco) { create(:budget_heading, group: group) }


### PR DESCRIPTION
## Objectives

To be able to support on a different budget heading within the same group if you have removed all the supports on the other heading.

