### PR TITLE
Remove duplicated calendar icon

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -716,24 +716,6 @@ code {
   }
 }
 
-.input-calendar-icon {
-  position: relative;
-
-  &::before {
-    color: $brand;
-    content: "\f133";
-    font-family: "Font Awesome 5 Free";
-    font-size: rem-calc(24);
-    left: 10px;
-    position: absolute;
-    top: 40px;
-  }
-
-  .input-calendar {
-    padding-left: $line-height * 1.5;
-  }
-}
-
 // 02. Sidebar
 // -----------
 

--- a/app/views/admin/budget_phases/_form.html.erb
+++ b/app/views/admin/budget_phases/_form.html.erb
@@ -13,15 +13,11 @@
     </div>
 
     <div class="small-12 medium-6 large-3 column">
-      <div class="input-calendar-icon">
-        <%= f.date_field :starts_at, id: "start_date" %>
-      </div>
+      <%= f.date_field :starts_at, id: "start_date" %>
     </div>
 
     <div class="small-12 medium-6 large-3 column end">
-      <div class="input-calendar-icon">
-        <%= f.date_field :ends_at, id: "end_date" %>
-      </div>
+      <%= f.date_field :ends_at, id: "end_date" %>
     </div>
   </div>
 


### PR DESCRIPTION
## Objectives

The date forms have been redesigned in the latest version of CONSUL and the CSS class `.input-calendar-icon` is no longer needed.

## Visual Changes

**BEFORE**
<img width="650" alt="Screenshot 2021-02-04 at 11 37 18" src="https://user-images.githubusercontent.com/631897/107040198-2d382200-67bf-11eb-8100-34d22146b1ef.png">

**AFTER**
<img width="649" alt="Screenshot 2021-02-05 at 14 29 23" src="https://user-images.githubusercontent.com/631897/107040203-30331280-67bf-11eb-8de8-8c2de0e07f55.png">
