### PR TITLE
Replace budget phase description max length

### DIFF
--- a/app/models/budget/phase.rb
+++ b/app/models/budget/phase.rb
@@ -4,7 +4,7 @@ class Budget
                 reviewing_ballots finished].freeze
     PUBLISHED_PRICES_PHASES = %w[publishing_prices balloting reviewing_ballots finished].freeze
     SUMMARY_MAX_LENGTH = 1000
-    DESCRIPTION_MAX_LENGTH = 2000
+    DESCRIPTION_MAX_LENGTH = 4000
 
     translates :name, touch: true
     translates :summary, touch: true


### PR DESCRIPTION
## Objectives

Replace budget phase `DESCRIPTION_MAX_LENGTH` from `2000` to `4000`.
