### PR TITLE
Increase description max length

### DIFF
--- a/app/models/concerns/measurable.rb
+++ b/app/models/concerns/measurable.rb
@@ -15,7 +15,7 @@ module Measurable
     end
 
     def description_max_length
-      6000
+      7000
     end
   end
 end


### PR DESCRIPTION
## Objectives

Increase `description_max_length` from 6000 to 7000 characters.

