### PR TITLE
Avoid raising error undefined method `heading' for nil:NilClass

### DIFF
--- a/app/models/budget/ballot.rb
+++ b/app/models/budget/ballot.rb
@@ -53,7 +53,7 @@ class Budget
     def heading_for_group(group)
       return nil unless has_lines_in_group?(group)
 
-      investments.find_by(group: group).heading
+      investments.find_by(group: group)&.heading
     end
 
     def casted_offline?


### PR DESCRIPTION
## References

- Error https://errors.democrateam.com/apps/5dff36a7b2aa2903f8364ae4/problems/60e6ef41b2aa29034cf29f1b
- Error https://errors.democrateam.com/apps/5dff36a7b2aa2903f8364ae4/problems/60e6c968b2aa29034cf29f10

## Objectives

Avoid raising error undefined method `heading' for nil:NilClass