### PR TITLE
Use original image size on budget header

### DIFF
--- a/app/components/budgets/budget_component.html.erb
+++ b/app/components/budgets/budget_component.html.erb
@@ -1,6 +1,6 @@
 <% if budget.image.present? %>
   <div class="budget-header with-background-image"
-       style="background-image: url(<%= asset_url budget.image.attachment.url(:large) %>);">
+       style="background-image: url(<%= asset_url budget.image.attachment.url(:original) %>);">
 <% else %>
 <div class="budget-header">
 <% end %>


### PR DESCRIPTION
## Objectives

Use `original` image size instead of `large` on budget header.
