### PR TITLE
Replace admin information texts tabs

### DIFF
--- a/app/helpers/site_customization_helper.rb
+++ b/app/helpers/site_customization_helper.rb
@@ -19,6 +19,6 @@ module SiteCustomizationHelper
   end
 
   def information_texts_tabs
-    [:basic, :debates, :community, :proposals, :polls, :layouts, :mailers, :management, :welcome]
+    [:basic, :debates, :proposals, :polls, :budgets, :legislation, :layouts, :mailers, :management, :welcome]
   end
 end

--- a/config/locales/custom/nl/admin.yml
+++ b/config/locales/custom/nl/admin.yml
@@ -453,6 +453,8 @@ nl:
           proposals: "Initiatieven"
           polls: "Peilingen"
           layouts: "Website lay-out"
+          budgets: "Ideeën"
+          legislation: "Inspraak"
         buttons:
           save: "Opslaan"
       users: "Gebruikers"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -778,6 +778,8 @@ en:
           mailers: "Emails"
           management: "Management"
           welcome: "Welcome"
+          budgets: "Participatory budgeting"
+          legislation: "Collaborative Legislation"
         buttons:
           save: "Save"
           content_block:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -777,6 +777,8 @@ es:
           mailers: "Correos"
           management: "Gestión"
           welcome: "Bienvenido/a"
+          budgets: "Presupuestos Participativos"
+          legislation: "Legislación colaborativa"
         buttons:
           save: "Guardar cambios"
           content_block:

--- a/spec/system/admin/site_customization/information_texts_spec.rb
+++ b/spec/system/admin/site_customization/information_texts_spec.rb
@@ -4,42 +4,38 @@ describe "Admin custom information texts", :admin do
   scenario "page is correctly loaded" do
     visit admin_site_customization_information_texts_path
 
-    click_link "Basic customization"
+    visit admin_site_customization_information_texts_path(tab: "basic")
     expect(page).to have_content "Help about debates"
     expect(page).to have_content "Help about proposals"
     expect(page).to have_content "Help about voting"
     expect(page).to have_content "Help about collaborative legislation"
     expect(page).to have_content "Help with participatory budgets"
 
-    within("#information-texts-tabs") { click_link "Debates" }
+    visit admin_site_customization_information_texts_path(tab: "debates")
+    expect(page).to have_content "Help about debates"
 
-    expect(page).to have_content "Edit debate"
+    visit admin_site_customization_information_texts_path(tab: "budgets")
+    expect(page).to have_content "Help with participatory budgets"
 
-    within("#information-texts-tabs") { click_link "Community" }
-    expect(page).to have_content "Access the community"
+    visit admin_site_customization_information_texts_path(tab: "legislation")
+    expect(page).to have_content "Help about collaborative legislation"
 
-    within("#information-texts-tabs") { click_link "Proposals" }
+    visit admin_site_customization_information_texts_path(tab: "proposals")
     expect(page).to have_content "Create proposal"
 
-    within "#information-texts-tabs" do
-      click_link "Polls"
-    end
-
+    visit admin_site_customization_information_texts_path(tab: "polls")
     expect(page).to have_content "Results"
 
-    click_link "Layouts"
+    visit admin_site_customization_information_texts_path(tab: "layouts")
     expect(page).to have_content "Accessibility"
 
-    click_link "Emails"
+    visit admin_site_customization_information_texts_path(tab: "mailers")
     expect(page).to have_content "Confirm your email"
 
-    within "#information-texts-tabs" do
-      click_link "Management"
-    end
-
+    visit admin_site_customization_information_texts_path(tab: "management")
     expect(page).to have_content "This user account is already verified."
 
-    click_link "Welcome"
+    visit admin_site_customization_information_texts_path(tab: "welcome")
     expect(page).to have_content "See all debates"
   end
 


### PR DESCRIPTION
## Objectives

Replace admin information texts tabs. 

Remove "Community" tab and adds "Participatory budgeting" and "Collaborative Legislation" tabs.

