### PR TITLE
Hide valuating and finished budgets on homepage feeds

### DIFF
--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -59,6 +59,7 @@ class Budget < ApplicationRecord
   scope :balloting, -> { where(phase: "balloting") }
   scope :reviewing_ballots, -> { where(phase: "reviewing_ballots") }
   scope :finished, -> { where(phase: "finished") }
+  scope :feeds, -> { where.not(phase: "valuating").where.not(phase: "finished") }
 
   class << self; undef :open; end
   scope :open, -> { where.not(phase: "finished") }

--- a/app/models/widget/feed.rb
+++ b/app/models/widget/feed.rb
@@ -33,6 +33,6 @@ class Widget::Feed < ApplicationRecord
   end
 
   def budgets
-    Budget.published.order("created_at DESC").limit(limit)
+    Budget.published.feeds.order("created_at DESC").limit(limit)
   end
 end


### PR DESCRIPTION
## Objectives

Hide valuating and finished budgets on homepage feeds.
