### PR TITLE
Monitor CONSUL with monit

### DIFF
--- a/lib/capistrano/monit/conf.d/delayed_job.erb
+++ b/lib/capistrano/monit/conf.d/delayed_job.erb
@@ -1,0 +1,6 @@
+<% fetch(:delayed_job_workers).times do |n| %>
+check process delayed_job_worker_<%= n %> with pidfile <%= shared_path %>/tmp/pids/delayed_job.<%= n %>.pid
+  start program = "/etc/init.d/delayed_job start" as uid deploy
+  stop program = "/etc/init.d/delayed_job stop" as uid deploy
+  if 5 restarts within 5 cycles then timeout
+<% end %>

--- a/lib/capistrano/monit/conf.d/nginx.erb
+++ b/lib/capistrano/monit/conf.d/nginx.erb
@@ -1,0 +1,5 @@
+check process nginx with pidfile /var/run/nginx.pid
+  start program = "/etc/init.d/nginx start"
+  stop program = "/etc/init.d/nginx stop"
+  if children > 250 then restart
+  if 5 restarts within 5 cycles then timeout

--- a/lib/capistrano/monit/conf.d/postgres.erb
+++ b/lib/capistrano/monit/conf.d/postgres.erb
@@ -1,0 +1,5 @@
+check process postgresql with pidfile /var/run/postgresql/9.5-main.pid
+  start program = "/etc/init.d/postgresql start"
+  stop program = "/etc/init.d/postgresql stop"
+  if failed host localhost port 5432 protocol pgsql then restart
+  if 5 restarts within 5 cycles then timeout

--- a/lib/capistrano/monit/conf.d/puma.erb
+++ b/lib/capistrano/monit/conf.d/puma.erb
@@ -1,0 +1,4 @@
+check process <%= fetch(:application) %>_puma with pidfile <%= shared_path %>/tmp/pids/puma.pid
+  start program = "/etc/init.d/puma start" as uid deploy
+  stop program = "/etc/init.d/puma stop" as uid deploy
+  if 5 restarts within 5 cycles then timeout

--- a/lib/capistrano/monit/init.d/delayed_job.erb
+++ b/lib/capistrano/monit/init.d/delayed_job.erb
@@ -1,0 +1,23 @@
+#! /bin/sh
+
+export rvm_path=/home/deploy/.rvm
+
+case "$1" in
+  start)
+    echo -n "Starting delayed_job: "
+    cd /home/deploy/consul/current
+    RAILS_ENV=<%= fetch(:rails_env) %> /home/deploy/consul/rvm1scripts/rvm-auto.sh . bundle exec bin/delayed_job -n 2 start
+    echo "done."
+    ;;
+  stop)
+    echo -n "Stopping delayed_job: "
+    cd /home/deploy/consul/current
+    RAILS_ENV=<%= fetch(:rails_env) %> /home/deploy/consul/rvm1scripts/rvm-auto.sh . bundle exec bin/delayed_job -n 2 stop
+    echo "done."
+    ;;
+  *)
+    echo >&2 "Usage: $0 <start|stop>"
+    exit 1
+    ;;
+esac
+exit 0

--- a/lib/capistrano/monit/init.d/puma.erb
+++ b/lib/capistrano/monit/init.d/puma.erb
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+export rvm_path=/home/deploy/.rvm
+
+case $1 in
+  start)
+    cd /home/deploy/consul/current
+    /home/deploy/consul/rvm1scripts/rvm-auto.sh . bundle exec puma -C /home/deploy/consul/current/config/puma/<%= fetch(:rails_env) %>.rb --daemon
+    echo "Puma Started"
+    exit 0
+    ;;
+  stop)
+    cd /home/deploy/consul/current
+    /home/deploy/consul/rvm1scripts/rvm-auto.sh . bundle exec pumactl -S /home/deploy/consul/shared/tmp/pids/puma.state -F /home/deploy/consul/current/config/puma/<%= fetch(:rails_env) %>.rb stop
+    echo "Puma Stopped"
+    exit 0
+    ;;
+  *)
+    echo >&2 "Usage: $0 <start|stop>"
+    exit 1
+    ;;
+esac
+exit 0

--- a/lib/capistrano/monit/monit.rb
+++ b/lib/capistrano/monit/monit.rb
@@ -1,0 +1,74 @@
+set :init_config_files, %w[puma delayed_job]
+set :monit_config_files, %w[nginx postgres puma delayed_job]
+
+def upload_erb(from, to)
+  if File.exists?(from)
+    from_erb = StringIO.new(ERB.new(File.read(from)).result(binding))
+    upload! from_erb, to
+    info "copied: #{from} to: #{to}"
+  else
+    error "error #{from} not found"
+  end
+end
+
+namespace :monit do
+  desc "Install Monit"
+  task :install do
+    on roles(:all) do
+      execute "sudo apt-get -y install monit"
+    end
+  end
+
+  desc "Setup Monit"
+  task :setup do
+    on roles(:app) do
+      fetch(:init_config_files).each do |file|
+        execute "mkdir -p #{shared_path}/config/monit/init.d"
+        upload_erb "lib/capistrano/monit/init.d/#{file}.erb", "#{shared_path}/config/monit/init.d/#{file}"
+        execute "sudo cp #{shared_path}/config/monit/init.d/#{file} /etc/init.d/#{file}"
+        execute "sudo chmod +x /etc/init.d/#{file}"
+      end
+
+      fetch(:monit_config_files).each do |file|
+        execute "mkdir -p #{shared_path}/config/monit/conf.d"
+        upload_erb "lib/capistrano/monit/conf.d/#{file}.erb", "#{shared_path}/config/monit/conf.d/#{file}"
+        execute "sudo ln -nfs #{shared_path}/config/monit/conf.d/#{file} /etc/monit/conf.d/#{file}.conf"
+      end
+    end
+  end
+
+  %w[start stop restart].each do |command|
+    desc "Run Monit #{command} script"
+    task command do
+      on roles(:all) do
+        execute "sudo service monit #{command}"
+      end
+    end
+  end
+
+  desc "Reset Monit state to start monitoring again"
+  task :reset do
+    on roles(:all) do
+      execute "sudo rm /var/lib/monit/state"
+    end
+  end
+
+  desc "Clear Monit configuration"
+  task :clear do
+    on roles(:app) do
+      execute "sudo rm -rf #{shared_path}/config/monit"
+
+      fetch(:init_config_files).each do |file|
+        execute "sudo rm /etc/init.d/#{file}"
+      end
+
+      fetch(:monit_config_files).each do |file|
+        execute "sudo rm /etc/monit/conf.d/#{file}.conf"
+      end
+    end
+  end
+
+  after "monit:setup", "monit:restart"
+  after "monit:reset", "monit:restart"
+  after "monit:clear", "monit:restart"
+end


### PR DESCRIPTION
## Objectives

Monitor CONSUL with [monit](https://mmonit.com/)

Installation and configuration via Capistrano

## Main Commands

- Install `monit` if it has not been previously installed.

```
cap production monit:install
```

- Configure `monit` to start monitoring CONSUL.

```
cap production monit:setup
```

- Delete previous `monit` configuration to stop monitoring CONSUL.

```
cap production monit:clear
```

- Reset `monit`state to start monitoring again. In case any check has failed too many times and it's no longer being checked.

```
cap production monit:reset
```

## Notes
`monit` provides commands to start|stop|restart the service when you are logged into the server. It is also possible to run these commands from outside the server using capistrano.

- Run `cap production monit:start` from outside the server to execute the command `sudo service monit start` inside the server.
- Run `cap production monit:stop` from outside the server to execute the command `sudo service monit stop` inside the server.
- Run `cap production monit:restart` from outside the server to execute the command `sudo service monit restart` inside the server.