### PR TITLE
Upstream

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -271,6 +271,26 @@ aside {
   }
 }
 
+.draft-panels {
+
+  .draft-allegation .draft-text a {
+    color: $link;
+  }
+
+  .draft-allegation .draft-text h2 {
+    margin-bottom: $line-height / 3;
+    margin-top: 0;
+  }
+
+  ul,
+  ol {
+
+    li {
+      font-size: $base-font-size;
+    }
+  }
+}
+
 .back {
 
   .icon-angle-left {
@@ -466,6 +486,13 @@ body > header,
   background: #fff !important;
   justify-content: space-between;
 
+  @include breakpoint(small only) {
+
+    .menu {
+      margin-bottom: 0;
+    }
+  }
+
   .menu > li {
 
     a {
@@ -586,7 +613,10 @@ body > header,
 
 .subnavigation {
   background: $light;
-  padding: $line-height / 2 0;
+
+  @include breakpoint(medium) {
+    padding: $line-height / 2 0;
+  }
 }
 
 .subnavigation a {
@@ -639,9 +669,28 @@ body > header,
 
     &.opens-left > .is-dropdown-submenu {
       background: #fff;
+
+      @include breakpoint(small only) {
+        width: 100%;
+      }
     }
 
     &.is-dropdown-submenu-parent {
+
+      > a {
+
+        @include breakpoint(small only) {
+          display: inline;
+        }
+
+        &.is-active::after {
+          border: 0;
+          height: 4px;
+          left: 0;
+          top: unset;
+          width: calc(100% + 8px);
+        }
+      }
 
       > a::before {
         border: inset 6px;
@@ -651,14 +700,13 @@ body > header,
         content: "";
         display: block;
         position: absolute;
-        right: -7px;
-        top: 22px;
-      }
+        right: -8px;
+        top: 20px;
 
-      > a::after {
-        border: 0;
-        margin-top: -6px;
-        top: auto;
+        @include breakpoint(small only) {
+          right: -10px;
+          top: 8px;
+        }
       }
     }
 
@@ -673,8 +721,15 @@ body > header,
 
     a {
       font-size: 16px;
-      padding-left: $line-height / 4;
-      padding-right: $line-height / 4;
+      padding-right: $line-height / 2;
+
+      @include breakpoint(small only) {
+        line-height: $line-height * 2;
+      }
+
+      @include breakpoint(medium) {
+        padding-left: $line-height / 2;
+      }
     }
   }
 
@@ -727,6 +782,13 @@ body > header,
   border-bottom: 0;
 }
 
+.locale .locale-form {
+
+  @include breakpoint(small-only) {
+    padding-left: $line-height / 4;
+  }
+}
+
 // 2. Homepage and custom pages
 // ----------------------------
 
@@ -740,7 +802,6 @@ body > header,
       background-position: 100% 30%;
       background-repeat: no-repeat;
       background-size: contain;
-      margin-right: calc(#{$global-width / 2} - 50vw);
       margin-top: $line-height * 2;
       min-height: $line-height * 20;
     }
@@ -939,6 +1000,7 @@ body > header,
 }
 
 .feeds-participation {
+  display: block;
 
   @include breakpoint(medium) {
 
@@ -1968,6 +2030,17 @@ footer {
   }
 }
 
+.draft-panels .draft-allegation {
+
+  .draft-panel {
+    color: $text;
+  }
+
+  .calc-comments .comment-box {
+    overflow: auto;
+  }
+}
+
 .draft-panels .comments-on .calc-index .draft-index-rotated {
   margin-top: $line-height * 5;
 }
@@ -2235,6 +2308,33 @@ footer {
   }
 }
 
+.legislation-draft-versions-form .markdown-preview {
+  font-family: "Montserrat", sans-serif !important;
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: "Montserrat", sans-serif !important;
+    line-height: unset;
+  }
+
+  h1 {
+    font-size: rem-calc(44);
+  }
+
+  h2 {
+    font-size: rem-calc(34);
+  }
+
+  h3 {
+    font-size: rem-calc(24);
+    margin: 0;
+  }
+}
+
 // 8. Debates
 // --------------------
 
@@ -2259,10 +2359,6 @@ footer {
 .debate .votes,
 .debate-show .votes {
   border-left: 0;
-}
-
-.debate-show .votes {
-  text-align: left;
 }
 
 .debate,

--- a/app/views/budgets/ballot/_progress_bar.html.erb
+++ b/app/views/budgets/ballot/_progress_bar.html.erb
@@ -18,7 +18,9 @@
 
 <p class="progress-meter-text spent-amount-text" style="width: <%= ballot.percentage_spent(heading) %>%">
   <span id="amount_available" class="amount-available">
-    <small><%= t("budgets.progress_bar.available") %></small>
+    <% if @budget.show_money? %>
+      <small><%= t("budgets.progress_bar.available") %></small>
+    <% end %>
     <span><%= sanitize(ballot.amount_available_info(heading)) %></span>
   </span>
 </p>

--- a/app/views/budgets/investments/_header.html.erb
+++ b/app/views/budgets/investments/_header.html.erb
@@ -26,11 +26,9 @@
                 <h2>
                   <%= t("budgets.investments.index.by_heading", heading: @heading.name) %>
                 </h2>
-                <% if @budget.show_money? %>
-                  <div id="progress_bar">
-                    <%= render "budgets/ballot/progress_bar", ballot: @ballot, heading: @heading %>
-                  </div>
-                <% end %>
+                <div id="progress_bar">
+                  <%= render "budgets/ballot/progress_bar", ballot: @ballot, heading: @heading %>
+                </div>
               </div>
             <% else %>
               <h2>

--- a/app/views/debates/index.html.erb
+++ b/app/views/debates/index.html.erb
@@ -83,8 +83,8 @@
           <p><%= t("debates.index.section_footer.description") %></p>
           <p><%= t("debates.index.section_footer.help_text_1") %></p>
           <p><%= sanitize(t("debates.index.section_footer.help_text_2",
-                            org: link_to(t("debates.index.section_footer.help_text_link"),
-                                         new_user_registration_path))) %>
+                            org: link_to(Setting["org_name"],
+                                 new_user_registration_path))) %>
           </p>
         </div>
       <% end %>

--- a/app/views/layouts/_mailer_footer.html.erb
+++ b/app/views/layouts/_mailer_footer.html.erb
@@ -6,6 +6,12 @@
         <%= setting["org_name"] %></p>
 
         <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif; margin: 0;padding: 0;line-height: 1.5em;color: #222; font-size: 10px; margin-top: 12px;">
+          <%= sanitize(t("mailers.unsubscribe",
+                          link: link_to(t("mailers.unsubscribe_link"), account_url, target: "_blank")),
+                          attributes: %w[href target]) %>
+        </p>
+
+        <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif; margin: 0;padding: 0;line-height: 1.5em;color: #222; font-size: 10px; margin-top: 12px;">
         <%= t("mailers.no_reply") %></p>
       </td>
     </tr>

--- a/config/deploy-secrets.yml.example
+++ b/config/deploy-secrets.yml.example
@@ -1,19 +1,17 @@
 staging:
   deploy_to: "/home/deploy/consul"
-  ssh_port: "21"
-  server: "staging.consul.es"
+  ssh_port: "22"
+  server: xxx.xxx.xxx.xxx
+  db_server: "localhost"
   user: "deploy"
-
-preproduction:
-  deploy_to: "/home/deploy/consul"
-  ssh_port: "2222"
-  server1: xxx.xxx.xxx.xxx
-  server2: xxx.xxx.xxx.xxx
-  user: "deploy"
+  server_name: "xxx.xxx.xxx.xxx"
+  full_app_name: "consul"
 
 production:
   deploy_to: "/home/deploy/consul"
   ssh_port: "22"
   server1: xxx.xxx.xxx.xxx
-  server2: xxx.xxx.xxx.xxx
+  db_server: "localhost"
   user: "deploy"
+  server_name: "xxx.xxx.xxx.xxx"
+  full_app_name: "consul"

--- a/config/locales/custom/nl/activerecord.yml
+++ b/config/locales/custom/nl/activerecord.yml
@@ -56,7 +56,7 @@ nl:
         email_on_comment: "Stuur mij een mail wanneer iemand reageert op mijn initiatieven of discussies"
         email_on_comment_reply: "Stuur mij een mail wanneer iemand op mijn reactie reageert"
         email_on_direct_message: "Ontvang emails over privéberichten"
-        newsletter: "Ontvang emails over Stem van Groningen gerelateerde informatie"
+        newsletter: "Ontvang nieuwsbrieven van de website"
         public_activity: "Maak mijn activiteit openbaar"
         public_interests: "Maak de onderwerpen/labels die ik volg openbaar"
         recommended_debates: "Toon aanbevelingen voor discussie"

--- a/config/locales/custom/nl/budgets.yml
+++ b/config/locales/custom/nl/budgets.yml
@@ -5,7 +5,7 @@ nl:
         title: "Jouw keuze"
         no_balloted_group_yet: "Je hebt nog niet gestemd"
         voted:
-          one: "Je hebt op <span>1</span> ideeën gestemd"
+          one: "Je hebt op <span>1</span> idee gestemd"
           other: "Je hebt op <span>%{count}</span> ideeën gestemd"
         voted_info: "Je stem is bevestigd"
         voted_info_2: "Je kunt je stem altijd aanpassen tot deze fase wordt gesloten"

--- a/config/locales/custom/nl/general.yml
+++ b/config/locales/custom/nl/general.yml
@@ -50,8 +50,8 @@ nl:
         title: "Hulp bij discussies"
         description: "Start een discussie om je mening met anderen te delen over onderwerpen die jij belangrijk vindt."
         help_text_1: "Deel je mening over allerlei onderwerpen, kansen of knelpunten die jij belangrijk vindt."
-        help_text_2: "Om een discussie te starten of om deel te nemen aan een discussie moet je je %{org}."
-        help_text_link: "registreren"
+        help_text_2: "Om een discussie te starten of om deel te nemen aan een discussie moet je je registreren op %{org}."
+        help_text_link: "aanmelden"
       title: "Discussies"
       search_form:
         title: "Zoek"

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -2,6 +2,8 @@ en:
   mailers:
     title: "Open Government"
     no_reply: "This message was sent from an email address that does not accept replies."
+    unsubscribe: "If you want to stop receiving these emails, you can change your preferences on the \"%{link}\" page."
+    unsubscribe_link: "My Account"
     comment:
       hi: Hi
       new_comment_by: There is a new comment from <strong>%{commenter}</strong>

--- a/config/locales/es/mailers.yml
+++ b/config/locales/es/mailers.yml
@@ -2,6 +2,8 @@ es:
   mailers:
     title: "Gobierno abierto"
     no_reply: "Este mensaje se ha enviado desde una dirección de correo electrónico que no admite respuestas."
+    unsubscribe: "Si quieres dejar de recibir estos emails, puedes cambiar tus preferencias en \"%{link}\"."
+    unsubscribe_link: "Mi cuenta"
     comment:
       hi: Hola
       new_comment_by: Hay un nuevo comentario de <strong>%{commenter}</strong> en

--- a/config/locales/nl/mailers.yml
+++ b/config/locales/nl/mailers.yml
@@ -1,6 +1,8 @@
 nl:
   mailers:
     no_reply: "This message was sent from an email address that does not accept replies."
+    unsubscribe: "Wanneer je dit soort e-mails niet meer wilt ontvangen, verander dan de instellingen op de \"%{link}\" pagina."
+    unsubscribe_link: "Mijn Profiel"
     comment:
       hi: Hi
       new_comment_by: There is a new comment from <strong>%{commenter}</strong>

--- a/lib/admin_legislation_sanitizer.rb
+++ b/lib/admin_legislation_sanitizer.rb
@@ -1,6 +1,6 @@
 class AdminLegislationSanitizer < WYSIWYGSanitizer
   def allowed_tags
-    super + %w[img h1 h2 h3 h4 h5 h6 p ul ol li strong em u s a table thead tbody tr th td]
+    super + %w[img h1 h2 h3 h4 h5 h6 hr blockquote code p ul ol li strong em u s a table thead tbody tr th td]
   end
 
   def allowed_attributes

--- a/lib/capistrano/monit/conf.d/postgres.erb
+++ b/lib/capistrano/monit/conf.d/postgres.erb
@@ -1,4 +1,4 @@
-check process postgresql with pidfile /var/run/postgresql/9.5-main.pid
+check process postgresql with pidfile /var/run/postgresql/12-main.pid
   start program = "/etc/init.d/postgresql start"
   stop program = "/etc/init.d/postgresql stop"
   if failed host localhost port 5432 protocol pgsql then restart

--- a/lib/capistrano/monit/conf.d/postgres.erb
+++ b/lib/capistrano/monit/conf.d/postgres.erb
@@ -1,4 +1,4 @@
-check process postgresql with pidfile /var/run/postgresql/12-main.pid
+check process postgresql with pidfile /var/run/postgresql/9.5-main.pid
   start program = "/etc/init.d/postgresql start"
   stop program = "/etc/init.d/postgresql stop"
   if failed host localhost port 5432 protocol pgsql then restart

--- a/spec/models/legislation/draft_version_spec.rb
+++ b/spec/models/legislation/draft_version_spec.rb
@@ -23,7 +23,11 @@ describe Legislation::DraftVersion do
     <<~BODY_MARKDOWN
       # Title 1
 
+      ---
+
       Some paragraph.
+
+      > Blockquote
 
       A list:
 
@@ -37,6 +41,13 @@ describe Legislation::DraftVersion do
       # Title 2
 
       Something about this.
+
+      `code`
+
+      | Syntax | Description |
+      | ----------- | ----------- |
+      | Header | Title |
+      | Paragraph | Text |
     BODY_MARKDOWN
   end
 
@@ -44,7 +55,13 @@ describe Legislation::DraftVersion do
     <<~BODY_HTML
       <h1 id="title-1">Title 1</h1>
 
+      <hr>
+
       <p>Some paragraph.</p>
+
+      <blockquote>
+      <p>Blockquote</p>
+      </blockquote>
 
       <p>A list:</p>
 
@@ -60,6 +77,24 @@ describe Legislation::DraftVersion do
       <h1 id="title-2">Title 2</h1>
 
       <p>Something about this.</p>
+
+      <p><code>code</code></p>
+
+      <table><thead>
+      <tr>
+      <th>Syntax</th>
+      <th>Description</th>
+      </tr>
+      </thead><tbody>
+      <tr>
+      <td>Header</td>
+      <td>Title</td>
+      </tr>
+      <tr>
+      <td>Paragraph</td>
+      <td>Text</td>
+      </tr>
+      </tbody></table>
     BODY_HTML
   end
 

--- a/spec/system/admin/system_emails_spec.rb
+++ b/spec/system/admin/system_emails_spec.rb
@@ -26,6 +26,20 @@ describe "System Emails" do
           end
         end
       end
+
+      scenario "have unsubscribe information" do
+        create(:comment, parent: create(:comment))
+        admin = create(:administrator)
+        create(:comment, :valuation, commentable: create(:budget_investment, administrator: admin))
+
+        system_emails.each do |email_id|
+          visit admin_system_email_view_path(email_id.to_s)
+
+          expect(page).to have_content "If you want to stop receiving these emails, you can change your "\
+                                       "preferences on the \"My Account\" page."
+          expect(page).to have_link "My account", href: account_path
+        end
+      end
     end
 
     context "System emails with preview" do

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -1560,8 +1560,8 @@ describe "Budget Investments" do
       end
     end
 
-    scenario "Do not show progress bar with hidden money" do
-      budget_hide_money = create(:budget, :hide_money, phase: "balloting")
+    scenario "Do not show progress bar money with hidden money" do
+      budget_hide_money = create(:budget, :hide_money, phase: "balloting", voting_style: "approval")
       group = create(:budget_group, budget: budget_hide_money)
       heading = create(:budget_heading, name: "Heading without money", group: group)
       user = create(:user, :level_two)
@@ -1569,15 +1569,20 @@ describe "Budget Investments" do
       visit budget_investments_path(budget_hide_money, heading: heading)
 
       expect(page).not_to have_content budget.formatted_heading_price(heading).to_s
+      expect(page).not_to have_content "€"
       expect(page).not_to have_css(".tagline")
 
       login_as(user)
 
       visit budget_investments_path(budget_hide_money, heading: heading)
 
-      expect(page).not_to have_css("#progress_bar")
+      expect(page).to have_content "YOU CAN VOTE 1 PROJECT VOTES CAST: 0 / YOU CAN VOTE 1 PROJECT"
+      expect(page).to have_content "YOU CAN STILL CAST 1 VOTE."
+      expect(page).not_to have_content "Available budget"
+
+      expect(page).to have_css("#progress_bar")
+      expect(page).to have_css("#amount_available")
       expect(page).not_to have_css("#amount_spent")
-      expect(page).not_to have_css("#amount_available")
     end
 
     scenario "Highlight voted heading" do


### PR DESCRIPTION
## Objectives

- Bump rails from 5.2.6 to 5.2.7.
- Bump Rails from 5.2.7 to 5.2.7.1.
- Move banner styles to their own stylesheet.
- Fix banner link on Chromium 101.
- Allow send newsletters with images.
- Fix margins on header content.
- Update deploy-secrets.yml.example.
- Monitor CONSUL with monit.
- Improve subnavigation styles on mobile screens.
- Fix deployment error after adding monit.
- Fix link to comments on admin view for debates.
- Add new tags on legislation markdown.
- Fix subnavigation dropdown menu styles.
- Fix homepage feeds participation layout.
- Update custom nl text.
- Add unsubscribe info on system emails.
- Fix debate show votes alignment.
- Fix draft comments button alignment.
- Update custom texts.
- Show progress bar for all budgets.
- Replace budget feeds date phase.
- Show participation not allowed message on mobile.
- Add wysiwyg to poll description and summary.
- Add read less button on poll header.
- Fix data-toggle on poll answer description.
- Add background color to mobile menu.
