### PR TITLE
Allow target and rel attributes to wysiwyg

### DIFF
--- a/lib/wysiwyg_sanitizer.rb
+++ b/lib/wysiwyg_sanitizer.rb
@@ -4,7 +4,7 @@ class WYSIWYGSanitizer
   end
 
   def allowed_attributes
-    %w[href]
+    %w[href target rel]
   end
 
   def sanitize(html)

--- a/spec/system/proposals_spec.rb
+++ b/spec/system/proposals_spec.rb
@@ -508,6 +508,11 @@ describe "Proposals" do
 
     expect(page).to have_content "Testing auto link"
     expect(page).to have_link("www.example.org", href: "http://www.example.org")
+
+    within ".proposal-show" do
+      expect(find_link("www.example.org")[:rel]).to eq("nofollow")
+      expect(find_link("www.example.org")[:target]).to eq("_blank")
+    end
   end
 
   scenario "JS injection is prevented but autolinking is respected", :no_js do


### PR DESCRIPTION
## Objectives

Allow `target` and `rel` attributes to wysiwyg content.