### PR TITLE
Add author estimation cost to budget investments

### DIFF
--- a/app/components/budgets/investments/form_component.html.erb
+++ b/app/components/budgets/investments/form_component.html.erb
@@ -48,6 +48,15 @@
       </div>
     <% end %>
 
+    <% if budget.show_money? %>
+      <%= f.label :author_estimation_cost, t("budgets.investments.form.author_estimation_cost",
+                                             currency: budget.currency_symbol) %>
+      <p class="help-text">
+        <%= t("budgets.investments.form.author_estimation_cost_help") %>
+      </p>
+      <%= f.number_field :author_estimation_cost, label: false %>
+    <% end %>
+
     <% if feature?(:map) %>
       <div>
         <%= render "map_locations/form_fields",

--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -124,6 +124,7 @@ module Budgets
       def allowed_params
         attributes = [:heading_id, :tag_list, :organization_name, :location,
                       :terms_of_service, :related_sdg_list,
+                      :author_estimation_cost,
                       image_attributes: image_attributes,
                       documents_attributes: document_attributes,
                       map_location_attributes: map_location_attributes]

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -349,6 +349,11 @@ class Budget
       feasible? && valuation_finished? && feasibility_explanation.present?
     end
 
+    def should_show_author_estimation_cost?
+      phases = %w[accepting reviewing selecting valuating]
+      author_estimation_cost.present? && phases.include?(budget.current_phase.kind)
+    end
+
     def formatted_price
       budget.formatted_amount(price)
     end

--- a/app/views/budgets/investments/_investment_detail.erb
+++ b/app/views/budgets/investments/_investment_detail.erb
@@ -26,6 +26,13 @@
 
 <%= auto_link_already_sanitized_html wysiwyg(investment.description) %>
 
+<% if investment.should_show_author_estimation_cost? %>
+  <p>
+    <strong><%= t("budgets.investments.show.author_estimation_cost") %></strong>
+    <%= @budget.formatted_amount(investment.author_estimation_cost) %>
+  </p>
+<% end %>
+
 <% if feature?(:map) && map_location_available?(@investment.map_location) %>
   <div class="margin">
     <%= render_map(investment.map_location, "budget_investment", false, nil) %>

--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -10,6 +10,7 @@
 <% cache [locale_and_user_status(investment),
           investment,
           investment.author,
+          investment.author_estimation_cost,
           Flag.flagged?(current_user, investment),
           investment.followed_by?(current_user),
           feature?(:remove_investments_supports),

--- a/config/locales/custom/en/budgets.yml
+++ b/config/locales/custom/en/budgets.yml
@@ -3,6 +3,7 @@ en:
     investments:
       show:
         edit: "Edit"
+        author_estimation_cost: "Estimated cost by the author:"
       new:
         recommendations_title: "Describe the idea. Think for example of:"
         recommendation_one: "Why is it a good idea?"
@@ -10,3 +11,6 @@ en:
         recommendation_three: "Is it once-only (like an activity) or for several years (like a facility)?"
         recommendation_four: "How much money do you think you will need for it? (optional, estimation is also fine)"
         recommendation_five: "What would you like to do yourself for the realization of the idea?"
+      form:
+        author_estimation_cost: "Estimated cost (%{currency})"
+        author_estimation_cost_help: "Estimated cost of realizing this idea."

--- a/config/locales/custom/nl/budgets.yml
+++ b/config/locales/custom/nl/budgets.yml
@@ -131,7 +131,7 @@ nl:
         title: "Ideeën"
       show:
         supports: "Vind ik leuk"
-        location: "Locatie: <strong>%{location}</strong>"
+        location: "<strong>Locatie:</strong> %{location}"
         organization_name: "Idee ingediend door: <strong>%{name}</strong>"
         author: "Indiener"
         comments_tab: "Reacties"
@@ -146,6 +146,7 @@ nl:
         price_explanation: "Waarom zijn dit de kosten?"
         votes: "Stemmen"
         edit: "Bewerk je idee"
+        author_estimation_cost: "Geschatte kosten van de indiener van het idee:"
       form:
         title: "Deel een idee"
         map_location_instructions: "Klik op de kaart om de locatie aan te geven. Je kunt de kaart bewegen"
@@ -156,6 +157,8 @@ nl:
         updated_notice: "Je idee is bewerkt."
         tag_category_label: "Thema's"
         tags_placeholder: "Als je meerdere thema's wilt toevoegen, scheidt ze dan door komma's (thema, thema)"
+        author_estimation_cost: "Geschatte kosten (%{currency})"
+        author_estimation_cost_help: "Kun je een schatting maken van wat het idee ongeveer kost? Vult dat dan hier in."
       investment:
         add: "Stem op dit idee"
         add_label: "Stem %{investment}"

--- a/db/migrate/20230403125448_add_author_estimation_cost_to_budget_investments.rb
+++ b/db/migrate/20230403125448_add_author_estimation_cost_to_budget_investments.rb
@@ -1,0 +1,5 @@
+class AddAuthorEstimationCostToBudgetInvestments < ActiveRecord::Migration[5.2]
+  def change
+    add_column :budget_investments, :author_estimation_cost, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_15_073305) do
+ActiveRecord::Schema.define(version: 2023_04_03_125448) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -299,6 +299,7 @@ ActiveRecord::Schema.define(version: 2023_02_15_073305) do
     t.integer "cached_votes_down", default: 0
     t.integer "cached_votes_total", default: 0
     t.text "feasibility_explanation"
+    t.bigint "author_estimation_cost"
     t.index ["administrator_id"], name: "index_budget_investments_on_administrator_id"
     t.index ["author_id"], name: "index_budget_investments_on_author_id"
     t.index ["budget_id"], name: "index_budget_investments_on_budget_id"


### PR DESCRIPTION
## Objectives

Add author estimation cost to budget investments.

## Visual Changes

### New investment form
![form](https://user-images.githubusercontent.com/631897/229835944-8297a2f9-ebca-4b1e-b167-99e30d38dea8.png)

### Investment show
![show](https://user-images.githubusercontent.com/631897/229835966-e1c830d5-61f7-40b4-afbb-5356f002cc91.png)

