### PR TITLE
Add missing space on budgets dates

### DIFF
--- a/config/locales/nl/rails.yml
+++ b/config/locales/nl/rails.yml
@@ -193,6 +193,6 @@ nl:
       default: "%a %d %b %Y %H:%M:%S %Z"
       long: "%d %B %Y %H:%M"
       short: "%d %b %H:%M"
-      short_datetime: "%Y-%m-%d%H:%M"
+      short_datetime: "%Y-%m-%d %H:%M"
       api: "%Y-%m-%d %H"
     pm: '''s middags'


### PR DESCRIPTION
## Objectives

Add missing space on budgets dates.

## Visual Changes

### Before
![before](https://github.com/StemvanGroningen/consul/assets/631897/e9247702-c8d2-4bad-a447-3352a3bdf5e5)

### After
![after](https://github.com/StemvanGroningen/consul/assets/631897/4ea9a643-bc9a-4229-8a0f-e99e5bb49d9c)
